### PR TITLE
Wikidata languages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/everypolitician/commons-builder.git
-  revision: 00ac90c431c7a3f60f3a5d438c68b252a1a85e73
+  revision: 0e34a060ae8b124e4e1131bb540379ea1f5acccc
   specs:
     commons-builder (0.1.0)
       rest-client (~> 2.0.2)
@@ -8,7 +8,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)

--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
-  "language_map": {
-    "lang:es_LA": "es",
-    "lang:gn_PY": "gn",
-    "lang:en_US": "en"
-  },
+  "languages": [
+    "es",
+    "gn",
+    "en"
+  ],
   "country_wikidata_id": "Q733"
 }

--- a/executive/Q51833296/current/popolo-m17n.json
+++ b/executive/Q51833296/current/popolo-m17n.json
@@ -2,9 +2,9 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Emiliano González Navero",
-        "lang:gn_PY": "Emiliano González Navero",
-        "lang:en_US": "Emiliano González Navero"
+        "lang:es": "Emiliano González Navero",
+        "lang:gn": "Emiliano González Navero",
+        "lang:en": "Emiliano González Navero"
       },
       "id": "Q150816",
       "identifiers": [
@@ -19,9 +19,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Benigno Ferreira",
-        "lang:gn_PY": "Benigno Ferreira",
-        "lang:en_US": "Benigno Ferreira"
+        "lang:es": "Benigno Ferreira",
+        "lang:gn": "Benigno Ferreira",
+        "lang:en": "Benigno Ferreira"
       },
       "id": "Q150829",
       "identifiers": [
@@ -36,8 +36,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Marcos Antonio Morínigo",
-        "lang:en_US": "Marcos Morínigo"
+        "lang:es": "Marcos Antonio Morínigo",
+        "lang:en": "Marcos Morínigo"
       },
       "id": "Q1653461",
       "identifiers": [
@@ -52,9 +52,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Rafael Franco",
-        "lang:gn_PY": "Rafael Franco",
-        "lang:en_US": "Rafael Franco"
+        "lang:es": "Rafael Franco",
+        "lang:gn": "Rafael Franco",
+        "lang:en": "Rafael Franco"
       },
       "id": "Q1654212",
       "identifiers": [
@@ -69,9 +69,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Luis Alberto Riart",
-        "lang:gn_PY": "Luis Alberto Riart",
-        "lang:en_US": "Luis Alberto Riart"
+        "lang:es": "Luis Alberto Riart",
+        "lang:gn": "Luis Alberto Riart",
+        "lang:en": "Luis Alberto Riart"
       },
       "id": "Q1654225",
       "identifiers": [
@@ -86,8 +86,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "José Patricio Guggiari",
-        "lang:en_US": "José Patricio Guggiari"
+        "lang:es": "José Patricio Guggiari",
+        "lang:en": "José Patricio Guggiari"
       },
       "id": "Q2357083",
       "identifiers": [
@@ -102,9 +102,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Eligio Ayala",
-        "lang:gn_PY": "Eligio Ayala",
-        "lang:en_US": "Eligio Ayala"
+        "lang:es": "Eligio Ayala",
+        "lang:gn": "Eligio Ayala",
+        "lang:en": "Eligio Ayala"
       },
       "id": "Q2357137",
       "identifiers": [
@@ -119,8 +119,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Cirilo Antonio Rivarola",
-        "lang:en_US": "Cirilo Antonio Rivarola"
+        "lang:es": "Cirilo Antonio Rivarola",
+        "lang:en": "Cirilo Antonio Rivarola"
       },
       "id": "Q2610334",
       "identifiers": [
@@ -135,9 +135,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Salvador Jovellanos",
-        "lang:gn_PY": "Salvador Jovellanos",
-        "lang:en_US": "Salvador Jovellanos"
+        "lang:es": "Salvador Jovellanos",
+        "lang:gn": "Salvador Jovellanos",
+        "lang:en": "Salvador Jovellanos"
       },
       "id": "Q26551",
       "identifiers": [
@@ -152,8 +152,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Higinio Uriarte",
-        "lang:en_US": "Higinio Uriarte"
+        "lang:es": "Higinio Uriarte",
+        "lang:en": "Higinio Uriarte"
       },
       "id": "Q26554",
       "identifiers": [
@@ -168,9 +168,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Juan Bautista Gill",
-        "lang:gn_PY": "Juan Bautista Gill",
-        "lang:en_US": "Juan Bautista Gill"
+        "lang:es": "Juan Bautista Gill",
+        "lang:gn": "Juan Bautista Gill",
+        "lang:en": "Juan Bautista Gill"
       },
       "id": "Q26560",
       "identifiers": [
@@ -185,8 +185,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Juan Carlos Wasmosy",
-        "lang:en_US": "Juan Carlos Wasmosy"
+        "lang:es": "Juan Carlos Wasmosy",
+        "lang:en": "Juan Carlos Wasmosy"
       },
       "id": "Q376549",
       "identifiers": [
@@ -201,9 +201,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Fulgencio Yegros",
-        "lang:gn_PY": "Fulgencio Yegros",
-        "lang:en_US": "Fulgencio Yegros"
+        "lang:es": "Fulgencio Yegros",
+        "lang:gn": "Fulgencio Yegros",
+        "lang:en": "Fulgencio Yegros"
       },
       "id": "Q37679",
       "identifiers": [
@@ -218,9 +218,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "José Félix Estigarribia",
-        "lang:gn_PY": "José Félix Estigarribia",
-        "lang:en_US": "José Félix Estigarribia"
+        "lang:es": "José Félix Estigarribia",
+        "lang:gn": "José Félix Estigarribia",
+        "lang:en": "José Félix Estigarribia"
       },
       "id": "Q379670",
       "identifiers": [
@@ -235,8 +235,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Pedro Pablo Peña",
-        "lang:en_US": "Pedro Peña"
+        "lang:es": "Pedro Pablo Peña",
+        "lang:en": "Pedro Peña"
       },
       "id": "Q387044",
       "identifiers": [
@@ -251,8 +251,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Adolfo Saguier",
-        "lang:en_US": "Adolfo Saguier"
+        "lang:es": "Adolfo Saguier",
+        "lang:en": "Adolfo Saguier"
       },
       "id": "Q390026",
       "identifiers": [
@@ -267,8 +267,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Juan José Medina",
-        "lang:en_US": "Juan José Medina"
+        "lang:es": "Juan José Medina",
+        "lang:en": "Juan José Medina"
       },
       "id": "Q430723",
       "identifiers": [
@@ -283,8 +283,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Andrés Rodríguez Pedotti",
-        "lang:en_US": "Andrés Rodríguez"
+        "lang:es": "Andrés Rodríguez Pedotti",
+        "lang:en": "Andrés Rodríguez"
       },
       "id": "Q440837",
       "identifiers": [
@@ -299,8 +299,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Raúl Cubas Grau",
-        "lang:en_US": "Raúl Cubas Grau"
+        "lang:es": "Raúl Cubas Grau",
+        "lang:en": "Raúl Cubas Grau"
       },
       "id": "Q460003",
       "identifiers": [
@@ -315,9 +315,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Eusebio Ayala",
-        "lang:gn_PY": "Eusebio Ayala",
-        "lang:en_US": "Eusebio Ayala"
+        "lang:es": "Eusebio Ayala",
+        "lang:gn": "Eusebio Ayala",
+        "lang:en": "Eusebio Ayala"
       },
       "id": "Q559950",
       "identifiers": [
@@ -332,9 +332,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Emilio Aceval",
-        "lang:gn_PY": "Emilio Aceval",
-        "lang:en_US": "Emilio Aceval"
+        "lang:es": "Emilio Aceval",
+        "lang:gn": "Emilio Aceval",
+        "lang:en": "Emilio Aceval"
       },
       "id": "Q561554",
       "identifiers": [
@@ -349,9 +349,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Horacio Cartes",
-        "lang:gn_PY": "Horacio Cartes",
-        "lang:en_US": "Horacio Cartes"
+        "lang:es": "Horacio Cartes",
+        "lang:gn": "Horacio Cartes",
+        "lang:en": "Horacio Cartes"
       },
       "id": "Q5901842",
       "identifiers": [
@@ -369,8 +369,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Tomás Romero Pereira",
-        "lang:en_US": "Tomás Romero Pereira"
+        "lang:es": "Tomás Romero Pereira",
+        "lang:en": "Tomás Romero Pereira"
       },
       "id": "Q601657",
       "identifiers": [
@@ -385,9 +385,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Juan Manuel Frutos",
-        "lang:gn_PY": "Juan Manuel Frutos",
-        "lang:en_US": "Juan Manuel Frutos"
+        "lang:es": "Juan Manuel Frutos",
+        "lang:gn": "Juan Manuel Frutos",
+        "lang:en": "Juan Manuel Frutos"
       },
       "id": "Q628530",
       "identifiers": [
@@ -402,9 +402,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Cándido Bareiro",
-        "lang:gn_PY": "Cándido Bareiro",
-        "lang:en_US": "Cándido Bareiro"
+        "lang:es": "Cándido Bareiro",
+        "lang:gn": "Cándido Bareiro",
+        "lang:en": "Cándido Bareiro"
       },
       "id": "Q730957",
       "identifiers": [
@@ -419,8 +419,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Bernardino Caballero",
-        "lang:en_US": "Bernardino Caballero"
+        "lang:es": "Bernardino Caballero",
+        "lang:en": "Bernardino Caballero"
       },
       "id": "Q738679",
       "identifiers": [
@@ -435,8 +435,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Manuel Gondra",
-        "lang:en_US": "Manuel Gondra"
+        "lang:es": "Manuel Gondra",
+        "lang:en": "Manuel Gondra"
       },
       "id": "Q860963",
       "identifiers": [
@@ -451,9 +451,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Cecilio Báez",
-        "lang:gn_PY": "Cecilio Báez",
-        "lang:en_US": "Cecilio Báez"
+        "lang:es": "Cecilio Báez",
+        "lang:gn": "Cecilio Báez",
+        "lang:en": "Cecilio Báez"
       },
       "id": "Q860978",
       "identifiers": [
@@ -468,9 +468,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Juan Gualberto González",
-        "lang:gn_PY": "Juan Gualberto González",
-        "lang:en_US": "Juan Gualberto González"
+        "lang:es": "Juan Gualberto González",
+        "lang:gn": "Juan Gualberto González",
+        "lang:en": "Juan Gualberto González"
       },
       "id": "Q860983",
       "identifiers": [
@@ -485,8 +485,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Manuel Franco",
-        "lang:en_US": "Manuel Franco"
+        "lang:es": "Manuel Franco",
+        "lang:en": "Manuel Franco"
       },
       "id": "Q860987",
       "identifiers": [
@@ -501,9 +501,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "José Pedro Montero",
-        "lang:gn_PY": "José Pedro Montero",
-        "lang:en_US": "José Pedro Montero"
+        "lang:es": "José Pedro Montero",
+        "lang:gn": "José Pedro Montero",
+        "lang:en": "José Pedro Montero"
       },
       "id": "Q860997",
       "identifiers": [
@@ -518,9 +518,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Eduardo Schaerer",
-        "lang:gn_PY": "Eduardo Schaerer",
-        "lang:en_US": "Eduardo Schaerer"
+        "lang:es": "Eduardo Schaerer",
+        "lang:gn": "Eduardo Schaerer",
+        "lang:en": "Eduardo Schaerer"
       },
       "id": "Q861003",
       "identifiers": [
@@ -535,8 +535,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Félix Paiva",
-        "lang:en_US": "Félix Paiva"
+        "lang:es": "Félix Paiva",
+        "lang:en": "Félix Paiva"
       },
       "id": "Q861008",
       "identifiers": [
@@ -551,8 +551,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Juan Bautista Egusquiza",
-        "lang:en_US": "Juan Bautista Egusquiza"
+        "lang:es": "Juan Bautista Egusquiza",
+        "lang:en": "Juan Bautista Egusquiza"
       },
       "id": "Q861014",
       "identifiers": [
@@ -567,9 +567,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Juan Natalicio González",
-        "lang:gn_PY": "Juan Natalicio González",
-        "lang:en_US": "Juan Natalicio González"
+        "lang:es": "Juan Natalicio González",
+        "lang:gn": "Juan Natalicio González",
+        "lang:en": "Juan Natalicio González"
       },
       "id": "Q861023",
       "identifiers": [
@@ -584,8 +584,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Juan Bautista Gaona",
-        "lang:en_US": "Juan Bautista Gaona"
+        "lang:es": "Juan Bautista Gaona",
+        "lang:en": "Juan Bautista Gaona"
       },
       "id": "Q861579",
       "identifiers": [
@@ -600,8 +600,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Liberato Marcial Rojas",
-        "lang:en_US": "Liberato Marcial Rojas"
+        "lang:es": "Liberato Marcial Rojas",
+        "lang:en": "Liberato Marcial Rojas"
       },
       "id": "Q861582",
       "identifiers": [
@@ -616,8 +616,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Albino Jara",
-        "lang:en_US": "Albino Jara"
+        "lang:es": "Albino Jara",
+        "lang:en": "Albino Jara"
       },
       "id": "Q861599",
       "identifiers": [
@@ -632,8 +632,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Higinio Morínigo",
-        "lang:en_US": "Higinio Moríñigo"
+        "lang:es": "Higinio Morínigo",
+        "lang:en": "Higinio Moríñigo"
       },
       "id": "Q887269",
       "identifiers": [
@@ -648,8 +648,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Federico Chaves",
-        "lang:en_US": "Federico Chávez"
+        "lang:es": "Federico Chaves",
+        "lang:en": "Federico Chávez"
       },
       "id": "Q888098",
       "identifiers": [
@@ -664,8 +664,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Mariano Roque Alonso",
-        "lang:en_US": "Mariano Roque Alonzo"
+        "lang:es": "Mariano Roque Alonso",
+        "lang:en": "Mariano Roque Alonzo"
       },
       "id": "Q888103",
       "identifiers": [
@@ -680,9 +680,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Raimundo Rolón",
-        "lang:gn_PY": "Raimundo Rolón",
-        "lang:en_US": "Raimundo Rolón"
+        "lang:es": "Raimundo Rolón",
+        "lang:gn": "Raimundo Rolón",
+        "lang:en": "Raimundo Rolón"
       },
       "id": "Q888249",
       "identifiers": [
@@ -697,9 +697,9 @@
     },
     {
       "name": {
-        "lang:es_LA": "Felipe Molas López",
-        "lang:gn_PY": "Felipe Molas López",
-        "lang:en_US": "Felipe Molas López"
+        "lang:es": "Felipe Molas López",
+        "lang:gn": "Felipe Molas López",
+        "lang:en": "Felipe Molas López"
       },
       "id": "Q888255",
       "identifiers": [
@@ -716,8 +716,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "Ministerios del Poder Ejecutivo",
-        "lang:en_US": "Ministries of Executive Power"
+        "lang:es": "Ministerios del Poder Ejecutivo",
+        "lang:en": "Ministries of Executive Power"
       },
       "id": "Q51833296",
       "classification": "branch",
@@ -731,8 +731,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Revolucionario Febrerista",
-        "lang:en_US": "Revolutionary Febrerista Party"
+        "lang:es": "Partido Revolucionario Febrerista",
+        "lang:en": "Revolutionary Febrerista Party"
       },
       "id": "Q1477511",
       "classification": "party",
@@ -745,8 +745,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Liberal Radical Auténtico",
-        "lang:en_US": "Authentic Radical Liberal Party"
+        "lang:es": "Partido Liberal Radical Auténtico",
+        "lang:en": "Authentic Radical Liberal Party"
       },
       "id": "Q2735114",
       "classification": "party",
@@ -759,7 +759,7 @@
     },
     {
       "name": {
-        "lang:en_US": "Liberal Party"
+        "lang:en": "Liberal Party"
       },
       "id": "Q6540713",
       "classification": "party",
@@ -772,8 +772,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Colorado",
-        "lang:en_US": "Colorado Party"
+        "lang:es": "Partido Colorado",
+        "lang:en": "Colorado Party"
       },
       "id": "Q928949",
       "classification": "party",
@@ -802,9 +802,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -822,15 +822,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -841,15 +841,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -860,15 +860,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -879,15 +879,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -898,15 +898,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -917,15 +917,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -936,15 +936,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -954,15 +954,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -973,15 +973,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -991,15 +991,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1010,15 +1010,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1028,15 +1028,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1047,15 +1047,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1066,15 +1066,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1084,15 +1084,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1102,15 +1102,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1121,15 +1121,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1140,15 +1140,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1159,15 +1159,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1178,15 +1178,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1197,15 +1197,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1216,15 +1216,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1234,15 +1234,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1252,15 +1252,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1271,15 +1271,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1290,15 +1290,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1309,15 +1309,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1328,15 +1328,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1347,15 +1347,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1366,15 +1366,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1385,15 +1385,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1404,15 +1404,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1423,15 +1423,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1442,15 +1442,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1461,15 +1461,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1480,15 +1480,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1498,15 +1498,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1517,15 +1517,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1535,15 +1535,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1554,15 +1554,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1573,15 +1573,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1591,15 +1591,15 @@
       "area_id": "Q733",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     },
     {
@@ -1611,15 +1611,15 @@
       "start_date": "2013-08-15",
       "role_superclass_code": "Q34071",
       "role_superclass": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es_LA": "Presidente del Paraguay",
-        "lang:gn_PY": "Tendota Paraguaigua",
-        "lang:en_US": "President of Paraguay"
+        "lang:es": "Presidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
       }
     }
   ]

--- a/executive/Q51833297/current/popolo-m17n.json
+++ b/executive/Q51833297/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Mario Ferreiro",
-        "lang:en_US": "Mario Ferreiro"
+        "lang:es": "Mario Ferreiro",
+        "lang:en": "Mario Ferreiro"
       },
       "id": "Q10708286",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "Gabinete de Asunción",
-        "lang:en_US": "Cabinet of Asuncion"
+        "lang:es": "Gabinete de Asunción",
+        "lang:en": "Cabinet of Asuncion"
       },
       "id": "Q51833297",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Revolucionario Febrerista",
-        "lang:en_US": "Revolutionary Febrerista Party"
+        "lang:es": "Partido Revolucionario Febrerista",
+        "lang:en": "Revolutionary Febrerista Party"
       },
       "id": "Q1477511",
       "classification": "party",
@@ -69,9 +69,9 @@
         "Q51842240"
       ],
       "type": {
-        "lang:es_LA": "capital",
-        "lang:gn_PY": "tavusu",
-        "lang:en_US": "capital"
+        "lang:es": "capital",
+        "lang:gn": "tavusu",
+        "lang:en": "capital"
       },
       "name": {
         "lang:es_LA": "Distrito Capital de Paraguay"
@@ -94,9 +94,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -114,13 +114,13 @@
       "area_id": "Q2933",
       "role_superclass_code": "Q51831955",
       "role_superclass": {
-        "lang:es_LA": "Intendente municipal de Asunción",
-        "lang:en_US": "Municipal mayor of Asuncion"
+        "lang:es": "Intendente municipal de Asunción",
+        "lang:en": "Municipal mayor of Asuncion"
       },
       "role_code": "Q51831955",
       "role": {
-        "lang:es_LA": "Intendente municipal de Asunción",
-        "lang:en_US": "Municipal mayor of Asuncion"
+        "lang:es": "Intendente municipal de Asunción",
+        "lang:en": "Municipal mayor of Asuncion"
       }
     }
   ]

--- a/executive/Q51833299/current/popolo-m17n.json
+++ b/executive/Q51833299/current/popolo-m17n.json
@@ -22,9 +22,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -49,9 +49,9 @@
         "Q51842212"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Concepción"

--- a/executive/Q51833300/current/popolo-m17n.json
+++ b/executive/Q51833300/current/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842213"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "San Pedro"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/executive/Q51833301/current/popolo-m17n.json
+++ b/executive/Q51833301/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Carlos María López",
-        "lang:en_US": "Carlos María López"
+        "lang:es": "Carlos María López",
+        "lang:en": "Carlos María López"
       },
       "id": "Q51885482",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "Gabinete del Departamento de Cordillera",
-        "lang:en_US": "Cabinet of the Department of Cordillera"
+        "lang:es": "Gabinete del Departamento de Cordillera",
+        "lang:en": "Cabinet of the Department of Cordillera"
       },
       "id": "Q51833301",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Liberal Radical Auténtico",
-        "lang:en_US": "Authentic Radical Liberal Party"
+        "lang:es": "Partido Liberal Radical Auténtico",
+        "lang:en": "Authentic Radical Liberal Party"
       },
       "id": "Q2735114",
       "classification": "party",
@@ -68,9 +68,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -95,9 +95,9 @@
         "Q51842214"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Cordillera"
@@ -114,13 +114,13 @@
       "area_id": "Q755121",
       "role_superclass_code": "Q51831958",
       "role_superclass": {
-        "lang:es_LA": "Gobernador del Departamento de Cordillera",
-        "lang:en_US": "Governor of the Department of Cordillera"
+        "lang:es": "Gobernador del Departamento de Cordillera",
+        "lang:en": "Governor of the Department of Cordillera"
       },
       "role_code": "Q51831958",
       "role": {
-        "lang:es_LA": "Gobernador del Departamento de Cordillera",
-        "lang:en_US": "Governor of the Department of Cordillera"
+        "lang:es": "Gobernador del Departamento de Cordillera",
+        "lang:en": "Governor of the Department of Cordillera"
       }
     }
   ]

--- a/executive/Q51833303/current/popolo-m17n.json
+++ b/executive/Q51833303/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Javier Silvera",
-        "lang:en_US": "Javier Silvera"
+        "lang:es": "Javier Silvera",
+        "lang:en": "Javier Silvera"
       },
       "id": "Q51885484",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "Gabinete del Departamento de Guairá",
-        "lang:en_US": "Cabinet of the Department of Guairá"
+        "lang:es": "Gabinete del Departamento de Guairá",
+        "lang:en": "Cabinet of the Department of Guairá"
       },
       "id": "Q51833303",
       "classification": "branch",
@@ -35,8 +35,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Colorado",
-        "lang:en_US": "Colorado Party"
+        "lang:es": "Partido Colorado",
+        "lang:en": "Colorado Party"
       },
       "id": "Q928949",
       "classification": "party",
@@ -65,9 +65,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -92,9 +92,9 @@
         "Q51842216"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Guairá"
@@ -111,13 +111,13 @@
       "area_id": "Q755116",
       "role_superclass_code": "Q51831959",
       "role_superclass": {
-        "lang:es_LA": "Gobernador del Departamento de Guairá",
-        "lang:en_US": "Governor of the Department of Guairá"
+        "lang:es": "Gobernador del Departamento de Guairá",
+        "lang:en": "Governor of the Department of Guairá"
       },
       "role_code": "Q51831959",
       "role": {
-        "lang:es_LA": "Gobernador del Departamento de Guairá",
-        "lang:en_US": "Governor of the Department of Guairá"
+        "lang:es": "Gobernador del Departamento de Guairá",
+        "lang:en": "Governor of the Department of Guairá"
       }
     }
   ]

--- a/executive/Q51833304/current/popolo-m17n.json
+++ b/executive/Q51833304/current/popolo-m17n.json
@@ -22,9 +22,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -49,9 +49,9 @@
         "Q51842217"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Caaguazú"

--- a/executive/Q51833305/current/popolo-m17n.json
+++ b/executive/Q51833305/current/popolo-m17n.json
@@ -22,9 +22,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -49,9 +49,9 @@
         "Q51842218"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Caazapá"

--- a/executive/Q51833306/current/popolo-m17n.json
+++ b/executive/Q51833306/current/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842219"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Itapúa"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/executive/Q51833313/current/popolo-m17n.json
+++ b/executive/Q51833313/current/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842220"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Misiones"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/executive/Q51833314/current/popolo-m17n.json
+++ b/executive/Q51833314/current/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842222"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Paraguarí"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/executive/Q51833315/current/popolo-m17n.json
+++ b/executive/Q51833315/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Fernando Schuster Salinas",
-        "lang:en_US": "Fernando Schuster Salinas"
+        "lang:es": "Fernando Schuster Salinas",
+        "lang:en": "Fernando Schuster Salinas"
       },
       "id": "Q51885483",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "Gabinete del Departamento de Alto Paraná",
-        "lang:en_US": "Cabinet of the Department of Alto Parana"
+        "lang:es": "Gabinete del Departamento de Alto Paraná",
+        "lang:en": "Cabinet of the Department of Alto Parana"
       },
       "id": "Q51833315",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Colorado",
-        "lang:en_US": "Colorado Party"
+        "lang:es": "Partido Colorado",
+        "lang:en": "Colorado Party"
       },
       "id": "Q928949",
       "classification": "party",
@@ -69,9 +69,9 @@
         "Q51842229"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Alto Paraná"
@@ -94,9 +94,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -114,13 +114,13 @@
       "area_id": "Q682654",
       "role_superclass_code": "Q51831976",
       "role_superclass": {
-        "lang:es_LA": "Gobernador del Departamento de Alto Paraná",
-        "lang:en_US": "Governor of the Department of Alto Parana"
+        "lang:es": "Gobernador del Departamento de Alto Paraná",
+        "lang:en": "Governor of the Department of Alto Parana"
       },
       "role_code": "Q51831976",
       "role": {
-        "lang:es_LA": "Gobernador del Departamento de Alto Paraná",
-        "lang:en_US": "Governor of the Department of Alto Parana"
+        "lang:es": "Gobernador del Departamento de Alto Paraná",
+        "lang:en": "Governor of the Department of Alto Parana"
       }
     }
   ]

--- a/executive/Q51833317/current/popolo-m17n.json
+++ b/executive/Q51833317/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Carlos Alberto Saldívar",
-        "lang:en_US": "Carlos Alberto Saldívar"
+        "lang:es": "Carlos Alberto Saldívar",
+        "lang:en": "Carlos Alberto Saldívar"
       },
       "id": "Q51885481",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "Gabinete del Departamento Central",
-        "lang:en_US": "Cabinet of the Department of Central"
+        "lang:es": "Gabinete del Departamento Central",
+        "lang:en": "Cabinet of the Department of Central"
       },
       "id": "Q51833317",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Colorado",
-        "lang:en_US": "Colorado Party"
+        "lang:es": "Partido Colorado",
+        "lang:en": "Colorado Party"
       },
       "id": "Q928949",
       "classification": "party",
@@ -69,9 +69,9 @@
         "Q51842230"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Central"
@@ -94,9 +94,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -114,13 +114,13 @@
       "area_id": "Q372461",
       "role_superclass_code": "Q51831977",
       "role_superclass": {
-        "lang:es_LA": "Gobernador del Departamento Central",
-        "lang:en_US": "Governor of the Department of Central"
+        "lang:es": "Gobernador del Departamento Central",
+        "lang:en": "Governor of the Department of Central"
       },
       "role_code": "Q51831977",
       "role": {
-        "lang:es_LA": "Gobernador del Departamento Central",
-        "lang:en_US": "Governor of the Department of Central"
+        "lang:es": "Gobernador del Departamento Central",
+        "lang:en": "Governor of the Department of Central"
       }
     }
   ]

--- a/executive/Q51833320/current/popolo-m17n.json
+++ b/executive/Q51833320/current/popolo-m17n.json
@@ -22,9 +22,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -49,9 +49,9 @@
         "Q51842231"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Ñeembucú"

--- a/executive/Q51833321/current/popolo-m17n.json
+++ b/executive/Q51833321/current/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842232"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Amambay"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/executive/Q51833322/current/popolo-m17n.json
+++ b/executive/Q51833322/current/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842235"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Canindeyú"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/executive/Q51833324/current/popolo-m17n.json
+++ b/executive/Q51833324/current/popolo-m17n.json
@@ -22,9 +22,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -49,9 +49,9 @@
         "Q51842237"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Presidente Hayes"

--- a/executive/Q51833325/current/popolo-m17n.json
+++ b/executive/Q51833325/current/popolo-m17n.json
@@ -22,9 +22,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -49,9 +49,9 @@
         "Q51842238"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Boquerón"

--- a/executive/Q51833333/current/popolo-m17n.json
+++ b/executive/Q51833333/current/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842239"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Alto Paraguay"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/executive/Q51885159/current/popolo-m17n.json
+++ b/executive/Q51885159/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Sandra María McLeod de Zacarías",
-        "lang:en_US": "Sandra María McLeod de Zacarías"
+        "lang:es": "Sandra María McLeod de Zacarías",
+        "lang:en": "Sandra María McLeod de Zacarías"
       },
       "id": "Q51885490",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "gabinete de Ciudad del Este",
-        "lang:en_US": "cabinet of Ciudad del Este"
+        "lang:es": "gabinete de Ciudad del Este",
+        "lang:en": "cabinet of Ciudad del Este"
       },
       "id": "Q51885159",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Colorado",
-        "lang:en_US": "Colorado Party"
+        "lang:es": "Partido Colorado",
+        "lang:en": "Colorado Party"
       },
       "id": "Q928949",
       "classification": "party",
@@ -69,8 +69,8 @@
         "Q51842246"
       ],
       "type": {
-        "lang:es_LA": "Municipio de Paraguay",
-        "lang:en_US": "district of Paraguay"
+        "lang:es": "Municipio de Paraguay",
+        "lang:en": "district of Paraguay"
       },
       "name": {
         "lang:es_LA": "Ciudad del Este"
@@ -94,9 +94,9 @@
         "Q51842229"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Alto Paraná"
@@ -119,9 +119,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -139,13 +139,13 @@
       "area_id": "Q192235",
       "role_superclass_code": "Q51885152",
       "role_superclass": {
-        "lang:es_LA": "intendente municipal de Ciudad del Este",
-        "lang:en_US": "municipal mayor of Ciudad del Este"
+        "lang:es": "intendente municipal de Ciudad del Este",
+        "lang:en": "municipal mayor of Ciudad del Este"
       },
       "role_code": "Q51885152",
       "role": {
-        "lang:es_LA": "intendente municipal de Ciudad del Este",
-        "lang:en_US": "municipal mayor of Ciudad del Este"
+        "lang:es": "intendente municipal de Ciudad del Este",
+        "lang:en": "municipal mayor of Ciudad del Este"
       }
     }
   ]

--- a/legislative/Q2119404/Q51884479/popolo-m17n.json
+++ b/legislative/Q2119404/Q51884479/popolo-m17n.json
@@ -2,9 +2,9 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Fernando Lugo",
-        "lang:gn_PY": "Fernando Lugo",
-        "lang:en_US": "Fernando Lugo"
+        "lang:es": "Fernando Lugo",
+        "lang:gn": "Fernando Lugo",
+        "lang:en": "Fernando Lugo"
       },
       "id": "Q151879",
       "identifiers": [
@@ -19,7 +19,7 @@
     },
     {
       "name": {
-        "lang:en_US": "Mario Abdo Benítez"
+        "lang:en": "Mario Abdo Benítez"
       },
       "id": "Q48136013",
       "identifiers": [
@@ -37,8 +37,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Mirta Leonor Gusinky",
-        "lang:en_US": "Mirta Leonor Gusinky"
+        "lang:es": "Mirta Leonor Gusinky",
+        "lang:en": "Mirta Leonor Gusinky"
       },
       "id": "Q51885473",
       "identifiers": [
@@ -56,8 +56,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Roberto Ramón Acevedo Quevedo",
-        "lang:en_US": "Roberto Ramón Acevedo Quevedo"
+        "lang:es": "Roberto Ramón Acevedo Quevedo",
+        "lang:en": "Roberto Ramón Acevedo Quevedo"
       },
       "id": "Q51885474",
       "identifiers": [
@@ -72,8 +72,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Desirée Graciela Masi Jara",
-        "lang:en_US": "Desirée Graciela Masi Jara"
+        "lang:es": "Desirée Graciela Masi Jara",
+        "lang:en": "Desirée Graciela Masi Jara"
       },
       "id": "Q51885475",
       "identifiers": [
@@ -93,8 +93,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "Cámara de Senadores de Paraguay",
-        "lang:en_US": "Senate of Paraguay"
+        "lang:es": "Cámara de Senadores de Paraguay",
+        "lang:en": "Senate of Paraguay"
       },
       "id": "Q2119404",
       "classification": "branch",
@@ -111,8 +111,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Frente Guasú",
-        "lang:en_US": "Frente Guasú"
+        "lang:es": "Frente Guasú",
+        "lang:en": "Frente Guasú"
       },
       "id": "Q11755876",
       "classification": "party",
@@ -125,8 +125,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Liberal Radical Auténtico",
-        "lang:en_US": "Authentic Radical Liberal Party"
+        "lang:es": "Partido Liberal Radical Auténtico",
+        "lang:en": "Authentic Radical Liberal Party"
       },
       "id": "Q2735114",
       "classification": "party",
@@ -139,8 +139,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Democrático Progresista (Paraguay)",
-        "lang:en_US": "Democratic Progressive Party"
+        "lang:es": "Partido Democrático Progresista (Paraguay)",
+        "lang:en": "Democratic Progressive Party"
       },
       "id": "Q3366435",
       "classification": "party",
@@ -153,8 +153,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Colorado",
-        "lang:en_US": "Colorado Party"
+        "lang:es": "Partido Colorado",
+        "lang:en": "Colorado Party"
       },
       "id": "Q928949",
       "classification": "party",
@@ -183,7 +183,7 @@
         "Q20058559"
       ],
       "type": {
-        "lang:en_US": "Constituency of the Senate of Paraguay"
+        "lang:en": "Constituency of the Senate of Paraguay"
       },
       "name": {
         "lang:es_LA": "circunscripción nacional",
@@ -207,9 +207,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -227,13 +227,13 @@
       "area_id": "Q51829445",
       "role_superclass_code": "Q15686806",
       "role_superclass": {
-        "lang:es_LA": "senador",
-        "lang:en_US": "senator"
+        "lang:es": "senador",
+        "lang:en": "senator"
       },
       "role_code": "Q20058559",
       "role": {
-        "lang:es_LA": "senador de Paraguay",
-        "lang:en_US": "senator of Paraguay"
+        "lang:es": "senador de Paraguay",
+        "lang:en": "senator of Paraguay"
       }
     },
     {
@@ -244,13 +244,13 @@
       "area_id": "Q51829445",
       "role_superclass_code": "Q15686806",
       "role_superclass": {
-        "lang:es_LA": "senador",
-        "lang:en_US": "senator"
+        "lang:es": "senador",
+        "lang:en": "senator"
       },
       "role_code": "Q20058559",
       "role": {
-        "lang:es_LA": "senador de Paraguay",
-        "lang:en_US": "senator of Paraguay"
+        "lang:es": "senador de Paraguay",
+        "lang:en": "senator of Paraguay"
       }
     },
     {
@@ -261,13 +261,13 @@
       "area_id": "Q51829445",
       "role_superclass_code": "Q15686806",
       "role_superclass": {
-        "lang:es_LA": "senador",
-        "lang:en_US": "senator"
+        "lang:es": "senador",
+        "lang:en": "senator"
       },
       "role_code": "Q20058559",
       "role": {
-        "lang:es_LA": "senador de Paraguay",
-        "lang:en_US": "senator of Paraguay"
+        "lang:es": "senador de Paraguay",
+        "lang:en": "senator of Paraguay"
       }
     },
     {
@@ -278,13 +278,13 @@
       "area_id": "Q51829445",
       "role_superclass_code": "Q15686806",
       "role_superclass": {
-        "lang:es_LA": "senador",
-        "lang:en_US": "senator"
+        "lang:es": "senador",
+        "lang:en": "senator"
       },
       "role_code": "Q20058559",
       "role": {
-        "lang:es_LA": "senador de Paraguay",
-        "lang:en_US": "senator of Paraguay"
+        "lang:es": "senador de Paraguay",
+        "lang:en": "senator of Paraguay"
       }
     },
     {
@@ -295,13 +295,13 @@
       "area_id": "Q51829445",
       "role_superclass_code": "Q15686806",
       "role_superclass": {
-        "lang:es_LA": "senador",
-        "lang:en_US": "senator"
+        "lang:es": "senador",
+        "lang:en": "senator"
       },
       "role_code": "Q20058559",
       "role": {
-        "lang:es_LA": "senador de Paraguay",
-        "lang:en_US": "senator of Paraguay"
+        "lang:es": "senador de Paraguay",
+        "lang:en": "senator of Paraguay"
       }
     }
   ]

--- a/legislative/Q320290/Q51884478/popolo-m17n.json
+++ b/legislative/Q320290/Q51884478/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Edgar Acosta Alcaráz",
-        "lang:en_US": "Edgar Acosta Alcaráz"
+        "lang:es": "Edgar Acosta Alcaráz",
+        "lang:en": "Edgar Acosta Alcaráz"
       },
       "id": "Q51885476",
       "identifiers": [
@@ -21,8 +21,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Perla Teresa Beatriz Acosta de Vázquez",
-        "lang:en_US": "Perla Teresa Beatriz Acosta de Vázquez"
+        "lang:es": "Perla Teresa Beatriz Acosta de Vázquez",
+        "lang:en": "Perla Teresa Beatriz Acosta de Vázquez"
       },
       "id": "Q51885477",
       "identifiers": [
@@ -37,8 +37,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "José Domingo Adorno Mazacotte",
-        "lang:en_US": "José Domingo Adorno Mazacotte"
+        "lang:es": "José Domingo Adorno Mazacotte",
+        "lang:en": "José Domingo Adorno Mazacotte"
       },
       "id": "Q51885478",
       "identifiers": [
@@ -53,8 +53,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Pedro Lorenzo Alliana Rodríguez",
-        "lang:en_US": "Pedro Lorenzo Alliana Rodríguez"
+        "lang:es": "Pedro Lorenzo Alliana Rodríguez",
+        "lang:en": "Pedro Lorenzo Alliana Rodríguez"
       },
       "id": "Q51885479",
       "identifiers": [
@@ -72,8 +72,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Eusebio Alvarenga Martínez",
-        "lang:en_US": "Eusebio Alvarenga Martínez"
+        "lang:es": "Eusebio Alvarenga Martínez",
+        "lang:en": "Eusebio Alvarenga Martínez"
       },
       "id": "Q51885480",
       "identifiers": [
@@ -93,8 +93,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "Cámara de Diputados de Paraguay",
-        "lang:en_US": "Chamber of Deputies"
+        "lang:es": "Cámara de Diputados de Paraguay",
+        "lang:en": "Chamber of Deputies"
       },
       "id": "Q320290",
       "classification": "branch",
@@ -111,8 +111,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Liberal Radical Auténtico",
-        "lang:en_US": "Authentic Radical Liberal Party"
+        "lang:es": "Partido Liberal Radical Auténtico",
+        "lang:en": "Authentic Radical Liberal Party"
       },
       "id": "Q2735114",
       "classification": "party",
@@ -125,8 +125,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Colorado",
-        "lang:en_US": "Colorado Party"
+        "lang:es": "Partido Colorado",
+        "lang:en": "Colorado Party"
       },
       "id": "Q928949",
       "classification": "party",
@@ -155,7 +155,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Distrito Capital de Paraguay"
@@ -178,7 +178,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Concepción"
@@ -201,7 +201,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "San Pedro"
@@ -224,7 +224,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Cordillera"
@@ -247,7 +247,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Guairá"
@@ -270,7 +270,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Caaguazú"
@@ -293,7 +293,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Caazapá"
@@ -316,7 +316,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Itapúa"
@@ -339,7 +339,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Misiones"
@@ -362,7 +362,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Paraguarí"
@@ -385,7 +385,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Alto Paraná"
@@ -408,7 +408,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Departamento Central"
@@ -431,7 +431,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Ñeembucú"
@@ -454,7 +454,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Amambay"
@@ -477,7 +477,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Canindeyú"
@@ -500,7 +500,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Presidente Hayes"
@@ -523,7 +523,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Boquerón"
@@ -546,7 +546,7 @@
         "Q20058561"
       ],
       "type": {
-        "lang:en_US": "constituency of the chamber of deputies of Paraguay"
+        "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
         "lang:es_LA": "Alto Paraguay"
@@ -569,9 +569,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -589,13 +589,13 @@
       "area_id": "Q51830053",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
-        "lang:es_LA": "diputado",
-        "lang:en_US": "deputy"
+        "lang:es": "diputado",
+        "lang:en": "deputy"
       },
       "role_code": "Q20058561",
       "role": {
-        "lang:es_LA": "diputado de Paraguay",
-        "lang:en_US": "deputy of Paraguay"
+        "lang:es": "diputado de Paraguay",
+        "lang:en": "deputy of Paraguay"
       }
     },
     {
@@ -606,13 +606,13 @@
       "area_id": "Q51830036",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
-        "lang:es_LA": "diputado",
-        "lang:en_US": "deputy"
+        "lang:es": "diputado",
+        "lang:en": "deputy"
       },
       "role_code": "Q20058561",
       "role": {
-        "lang:es_LA": "diputado de Paraguay",
-        "lang:en_US": "deputy of Paraguay"
+        "lang:es": "diputado de Paraguay",
+        "lang:en": "deputy of Paraguay"
       }
     },
     {
@@ -623,13 +623,13 @@
       "area_id": "Q51830063",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
-        "lang:es_LA": "diputado",
-        "lang:en_US": "deputy"
+        "lang:es": "diputado",
+        "lang:en": "deputy"
       },
       "role_code": "Q20058561",
       "role": {
-        "lang:es_LA": "diputado de Paraguay",
-        "lang:en_US": "deputy of Paraguay"
+        "lang:es": "diputado de Paraguay",
+        "lang:en": "deputy of Paraguay"
       }
     },
     {
@@ -640,13 +640,13 @@
       "area_id": "Q51830055",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
-        "lang:es_LA": "diputado",
-        "lang:en_US": "deputy"
+        "lang:es": "diputado",
+        "lang:en": "deputy"
       },
       "role_code": "Q20058561",
       "role": {
-        "lang:es_LA": "diputado de Paraguay",
-        "lang:en_US": "deputy of Paraguay"
+        "lang:es": "diputado de Paraguay",
+        "lang:en": "deputy of Paraguay"
       }
     },
     {
@@ -657,13 +657,13 @@
       "area_id": "Q51830038",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
-        "lang:es_LA": "diputado",
-        "lang:en_US": "deputy"
+        "lang:es": "diputado",
+        "lang:en": "deputy"
       },
       "role_code": "Q20058561",
       "role": {
-        "lang:es_LA": "diputado de Paraguay",
-        "lang:en_US": "deputy of Paraguay"
+        "lang:es": "diputado de Paraguay",
+        "lang:en": "deputy of Paraguay"
       }
     }
   ]

--- a/legislative/Q51839097/Q51884480/popolo-m17n.json
+++ b/legislative/Q51839097/Q51884480/popolo-m17n.json
@@ -22,9 +22,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -49,9 +49,9 @@
         "Q51842212"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Concepción"

--- a/legislative/Q51839098/Q51884481/popolo-m17n.json
+++ b/legislative/Q51839098/Q51884481/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Cristhian Ariel Delvalle Salas",
-        "lang:en_US": "Cristhian Ariel Delvalle Salas"
+        "lang:es": "Cristhian Ariel Delvalle Salas",
+        "lang:en": "Cristhian Ariel Delvalle Salas"
       },
       "id": "Q51885489",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "junta departmental de San Pedro",
-        "lang:en_US": "departmental board of San Pedro"
+        "lang:es": "junta departmental de San Pedro",
+        "lang:en": "departmental board of San Pedro"
       },
       "id": "Q51839098",
       "classification": "branch",
@@ -41,8 +41,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Liberal Radical Auténtico",
-        "lang:en_US": "Authentic Radical Liberal Party"
+        "lang:es": "Partido Liberal Radical Auténtico",
+        "lang:en": "Authentic Radical Liberal Party"
       },
       "id": "Q2735114",
       "classification": "party",
@@ -72,9 +72,9 @@
         "Q51842213"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "San Pedro"
@@ -97,9 +97,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -116,13 +116,13 @@
       "organization_id": "Q51839098",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842213",
       "role": {
-        "lang:es_LA": "concejal departamental de San Pedro",
-        "lang:en_US": "councillor for San Pedro department"
+        "lang:es": "concejal departamental de San Pedro",
+        "lang:en": "councillor for San Pedro department"
       }
     }
   ]

--- a/legislative/Q51839099/Q51884482/popolo-m17n.json
+++ b/legislative/Q51839099/Q51884482/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Espiridion Peña",
-        "lang:en_US": "Espiridion Peña"
+        "lang:es": "Espiridion Peña",
+        "lang:en": "Espiridion Peña"
       },
       "id": "Q51885487",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "junta departmental de Cordillera",
-        "lang:en_US": "departmental board of Cordillera"
+        "lang:es": "junta departmental de Cordillera",
+        "lang:en": "departmental board of Cordillera"
       },
       "id": "Q51839099",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Liberal Radical Auténtico",
-        "lang:en_US": "Authentic Radical Liberal Party"
+        "lang:es": "Partido Liberal Radical Auténtico",
+        "lang:en": "Authentic Radical Liberal Party"
       },
       "id": "Q2735114",
       "classification": "party",
@@ -68,9 +68,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -95,9 +95,9 @@
         "Q51842214"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Cordillera"
@@ -113,13 +113,13 @@
       "organization_id": "Q51839099",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842214",
       "role": {
-        "lang:es_LA": "concejal departamental de Cordillera",
-        "lang:en_US": "councillor for Cordillera department"
+        "lang:es": "concejal departamental de Cordillera",
+        "lang:en": "councillor for Cordillera department"
       }
     }
   ]

--- a/legislative/Q51839100/Q51884483/popolo-m17n.json
+++ b/legislative/Q51839100/Q51884483/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Gloria Mercedes Santo de Torres",
-        "lang:en_US": "Gloria Mercedes Santo de Torres"
+        "lang:es": "Gloria Mercedes Santo de Torres",
+        "lang:en": "Gloria Mercedes Santo de Torres"
       },
       "id": "Q51885486",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "junta departmental of Guairá",
-        "lang:en_US": "departmental board of Guairá"
+        "lang:es": "junta departmental of Guairá",
+        "lang:en": "departmental board of Guairá"
       },
       "id": "Q51839100",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Colorado",
-        "lang:en_US": "Colorado Party"
+        "lang:es": "Partido Colorado",
+        "lang:en": "Colorado Party"
       },
       "id": "Q928949",
       "classification": "party",
@@ -68,9 +68,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -95,9 +95,9 @@
         "Q51842216"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Guairá"
@@ -113,13 +113,13 @@
       "organization_id": "Q51839100",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842216",
       "role": {
-        "lang:es_LA": "concejal departamental de Guairá",
-        "lang:en_US": "councillor for Guairá department"
+        "lang:es": "concejal departamental de Guairá",
+        "lang:en": "councillor for Guairá department"
       }
     }
   ]

--- a/legislative/Q51839101/Q51884484/popolo-m17n.json
+++ b/legislative/Q51839101/Q51884484/popolo-m17n.json
@@ -22,9 +22,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -49,9 +49,9 @@
         "Q51842217"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Caaguazú"

--- a/legislative/Q51839102/Q51884485/popolo-m17n.json
+++ b/legislative/Q51839102/Q51884485/popolo-m17n.json
@@ -22,9 +22,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -49,9 +49,9 @@
         "Q51842218"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Caazapá"

--- a/legislative/Q51839103/Q51884486/popolo-m17n.json
+++ b/legislative/Q51839103/Q51884486/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842219"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Itapúa"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/legislative/Q51839104/Q51884488/popolo-m17n.json
+++ b/legislative/Q51839104/Q51884488/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842220"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Misiones"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/legislative/Q51839107/Q51884489/popolo-m17n.json
+++ b/legislative/Q51839107/Q51884489/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842222"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Paraguarí"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/legislative/Q51839114/Q51884490/popolo-m17n.json
+++ b/legislative/Q51839114/Q51884490/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Carlos Gustavo Benítez",
-        "lang:en_US": "Carlos Gustavo Benítez"
+        "lang:es": "Carlos Gustavo Benítez",
+        "lang:en": "Carlos Gustavo Benítez"
       },
       "id": "Q51885485",
       "identifiers": [
@@ -20,8 +20,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "junta departmental de Alto Paraná",
-        "lang:en_US": "departmental board of Alto Parana"
+        "lang:es": "junta departmental de Alto Paraná",
+        "lang:en": "departmental board of Alto Parana"
       },
       "id": "Q51839114",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Liberal Radical Auténtico",
-        "lang:en_US": "Authentic Radical Liberal Party"
+        "lang:es": "Partido Liberal Radical Auténtico",
+        "lang:en": "Authentic Radical Liberal Party"
       },
       "id": "Q2735114",
       "classification": "party",
@@ -69,9 +69,9 @@
         "Q51842229"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Alto Paraná"
@@ -94,9 +94,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -113,13 +113,13 @@
       "organization_id": "Q51839114",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842229",
       "role": {
-        "lang:es_LA": "concejal departamental de Alto Paraná",
-        "lang:en_US": "councillor for Alto Paraná department"
+        "lang:es": "concejal departamental de Alto Paraná",
+        "lang:en": "councillor for Alto Paraná department"
       }
     }
   ]

--- a/legislative/Q51839115/Q51884491/popolo-m17n.json
+++ b/legislative/Q51839115/Q51884491/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842230"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Central"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/legislative/Q51839117/Q51884492/popolo-m17n.json
+++ b/legislative/Q51839117/Q51884492/popolo-m17n.json
@@ -22,9 +22,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -49,9 +49,9 @@
         "Q51842231"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Ñeembucú"

--- a/legislative/Q51839118/Q51884493/popolo-m17n.json
+++ b/legislative/Q51839118/Q51884493/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842232"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Amambay"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/legislative/Q51839120/Q51884494/popolo-m17n.json
+++ b/legislative/Q51839120/Q51884494/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842235"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Canindeyú"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/legislative/Q51839121/Q51884495/popolo-m17n.json
+++ b/legislative/Q51839121/Q51884495/popolo-m17n.json
@@ -22,9 +22,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -49,9 +49,9 @@
         "Q51842237"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Presidente Hayes"

--- a/legislative/Q51839123/Q51884497/popolo-m17n.json
+++ b/legislative/Q51839123/Q51884497/popolo-m17n.json
@@ -22,9 +22,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -49,9 +49,9 @@
         "Q51842238"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Boquerón"

--- a/legislative/Q51839124/Q51884498/popolo-m17n.json
+++ b/legislative/Q51839124/Q51884498/popolo-m17n.json
@@ -23,9 +23,9 @@
         "Q51842239"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Alto Paraguay"
@@ -48,9 +48,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",

--- a/legislative/Q51839125/Q51884499/popolo-m17n.json
+++ b/legislative/Q51839125/Q51884499/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Augusto Alberto Wagner",
-        "lang:en_US": "Augusto Alberto Wagner"
+        "lang:es": "Augusto Alberto Wagner",
+        "lang:en": "Augusto Alberto Wagner"
       },
       "id": "Q51885488",
       "identifiers": [
@@ -21,8 +21,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Hugo Ramírez Ibarra",
-        "lang:en_US": "Hugo Ramírez Ibarra"
+        "lang:es": "Hugo Ramírez Ibarra",
+        "lang:en": "Hugo Ramírez Ibarra"
       },
       "id": "Q51885491",
       "identifiers": [
@@ -40,8 +40,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Daniel Centurión González",
-        "lang:en_US": "Daniel Centurión González"
+        "lang:es": "Daniel Centurión González",
+        "lang:en": "Daniel Centurión González"
       },
       "id": "Q51885492",
       "identifiers": [
@@ -59,8 +59,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Martín Arévalo Fernández",
-        "lang:en_US": "Martín Arévalo Fernández"
+        "lang:es": "Martín Arévalo Fernández",
+        "lang:en": "Martín Arévalo Fernández"
       },
       "id": "Q51885494",
       "identifiers": [
@@ -75,8 +75,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Silvia Fabiana Benegas de Sánchez",
-        "lang:en_US": "Silvia Fabiana Benegas de Sánchez"
+        "lang:es": "Silvia Fabiana Benegas de Sánchez",
+        "lang:en": "Silvia Fabiana Benegas de Sánchez"
       },
       "id": "Q51885495",
       "identifiers": [
@@ -96,8 +96,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "Junta Municipal de Asunción",
-        "lang:en_US": "Municipal Board of Asuncion"
+        "lang:es": "Junta Municipal de Asunción",
+        "lang:en": "Municipal Board of Asuncion"
       },
       "id": "Q51839125",
       "classification": "branch",
@@ -114,8 +114,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Liberal Radical Auténtico",
-        "lang:en_US": "Authentic Radical Liberal Party"
+        "lang:es": "Partido Liberal Radical Auténtico",
+        "lang:en": "Authentic Radical Liberal Party"
       },
       "id": "Q2735114",
       "classification": "party",
@@ -128,8 +128,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Colorado",
-        "lang:en_US": "Colorado Party"
+        "lang:es": "Partido Colorado",
+        "lang:en": "Colorado Party"
       },
       "id": "Q928949",
       "classification": "party",
@@ -159,9 +159,9 @@
         "Q51842240"
       ],
       "type": {
-        "lang:es_LA": "capital",
-        "lang:gn_PY": "tavusu",
-        "lang:en_US": "capital"
+        "lang:es": "capital",
+        "lang:gn": "tavusu",
+        "lang:en": "capital"
       },
       "name": {
         "lang:es_LA": "Distrito Capital de Paraguay"
@@ -184,9 +184,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -203,13 +203,13 @@
       "organization_id": "Q51839125",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842240",
       "role": {
-        "lang:es_LA": "concejal de Asunción",
-        "lang:en_US": "councillor for the city of Asunción"
+        "lang:es": "concejal de Asunción",
+        "lang:en": "councillor for the city of Asunción"
       }
     },
     {
@@ -219,13 +219,13 @@
       "organization_id": "Q51839125",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842240",
       "role": {
-        "lang:es_LA": "concejal de Asunción",
-        "lang:en_US": "councillor for the city of Asunción"
+        "lang:es": "concejal de Asunción",
+        "lang:en": "councillor for the city of Asunción"
       }
     },
     {
@@ -235,13 +235,13 @@
       "organization_id": "Q51839125",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842240",
       "role": {
-        "lang:es_LA": "concejal de Asunción",
-        "lang:en_US": "councillor for the city of Asunción"
+        "lang:es": "concejal de Asunción",
+        "lang:en": "councillor for the city of Asunción"
       }
     },
     {
@@ -251,13 +251,13 @@
       "organization_id": "Q51839125",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842240",
       "role": {
-        "lang:es_LA": "concejal de Asunción",
-        "lang:en_US": "councillor for the city of Asunción"
+        "lang:es": "concejal de Asunción",
+        "lang:en": "councillor for the city of Asunción"
       }
     },
     {
@@ -267,13 +267,13 @@
       "organization_id": "Q51839125",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842240",
       "role": {
-        "lang:es_LA": "concejal de Asunción",
-        "lang:en_US": "councillor for the city of Asunción"
+        "lang:es": "concejal de Asunción",
+        "lang:en": "councillor for the city of Asunción"
       }
     }
   ]

--- a/legislative/Q51839131/Q51884500/popolo-m17n.json
+++ b/legislative/Q51839131/Q51884500/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:es_LA": "Juan Carlos Barreto Miranda",
-        "lang:en_US": "Juan Carlos Barreto Miranda"
+        "lang:es": "Juan Carlos Barreto Miranda",
+        "lang:en": "Juan Carlos Barreto Miranda"
       },
       "id": "Q51885496",
       "identifiers": [
@@ -21,8 +21,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "María Portillo Verón",
-        "lang:en_US": "María Portillo Verón"
+        "lang:es": "María Portillo Verón",
+        "lang:en": "María Portillo Verón"
       },
       "id": "Q51885497",
       "identifiers": [
@@ -37,8 +37,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Miguel Coronel Sosa",
-        "lang:en_US": "Miguel Coronel Sosa"
+        "lang:es": "Miguel Coronel Sosa",
+        "lang:en": "Miguel Coronel Sosa"
       },
       "id": "Q51885498",
       "identifiers": [
@@ -56,8 +56,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Alejandro Zacarías McLeod",
-        "lang:en_US": "Alejandro Zacarías McLeod"
+        "lang:es": "Alejandro Zacarías McLeod",
+        "lang:en": "Alejandro Zacarías McLeod"
       },
       "id": "Q51885499",
       "identifiers": [
@@ -75,8 +75,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Juan Ángel Nuñez Duarte",
-        "lang:en_US": "Juan Ángel Nuñez Duarte"
+        "lang:es": "Juan Ángel Nuñez Duarte",
+        "lang:en": "Juan Ángel Nuñez Duarte"
       },
       "id": "Q51885501",
       "identifiers": [
@@ -96,8 +96,8 @@
   "organizations": [
     {
       "name": {
-        "lang:es_LA": "Junta Municipal de Ciudad del Este",
-        "lang:en_US": "Municipal Board of Ciudad del Este"
+        "lang:es": "Junta Municipal de Ciudad del Este",
+        "lang:en": "Municipal Board of Ciudad del Este"
       },
       "id": "Q51839131",
       "classification": "branch",
@@ -114,8 +114,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Liberal Radical Auténtico",
-        "lang:en_US": "Authentic Radical Liberal Party"
+        "lang:es": "Partido Liberal Radical Auténtico",
+        "lang:en": "Authentic Radical Liberal Party"
       },
       "id": "Q2735114",
       "classification": "party",
@@ -128,8 +128,8 @@
     },
     {
       "name": {
-        "lang:es_LA": "Partido Colorado",
-        "lang:en_US": "Colorado Party"
+        "lang:es": "Partido Colorado",
+        "lang:en": "Colorado Party"
       },
       "id": "Q928949",
       "classification": "party",
@@ -159,8 +159,8 @@
         "Q51842246"
       ],
       "type": {
-        "lang:es_LA": "Municipio de Paraguay",
-        "lang:en_US": "district of Paraguay"
+        "lang:es": "Municipio de Paraguay",
+        "lang:en": "district of Paraguay"
       },
       "name": {
         "lang:es_LA": "Ciudad del Este"
@@ -184,9 +184,9 @@
         "Q51842229"
       ],
       "type": {
-        "lang:es_LA": "departamento de Paraguay",
-        "lang:gn_PY": "Tetãvore Paraguái",
-        "lang:en_US": "department of Paraguay"
+        "lang:es": "departamento de Paraguay",
+        "lang:gn": "Tetãvore Paraguái",
+        "lang:en": "department of Paraguay"
       },
       "name": {
         "lang:es_LA": "Alto Paraná"
@@ -209,9 +209,9 @@
         "Q34071"
       ],
       "type": {
-        "lang:es_LA": "país",
-        "lang:gn_PY": "tetã",
-        "lang:en_US": "country"
+        "lang:es": "país",
+        "lang:gn": "tetã",
+        "lang:en": "country"
       },
       "name": {
         "lang:en_US": "Republic of Paraguay",
@@ -228,13 +228,13 @@
       "organization_id": "Q51839131",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842246",
       "role": {
-        "lang:es_LA": "concejal de Ciudad del Este",
-        "lang:en_US": "councillor for the city of Ciudad del Este"
+        "lang:es": "concejal de Ciudad del Este",
+        "lang:en": "councillor for the city of Ciudad del Este"
       }
     },
     {
@@ -244,13 +244,13 @@
       "organization_id": "Q51839131",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842246",
       "role": {
-        "lang:es_LA": "concejal de Ciudad del Este",
-        "lang:en_US": "councillor for the city of Ciudad del Este"
+        "lang:es": "concejal de Ciudad del Este",
+        "lang:en": "councillor for the city of Ciudad del Este"
       }
     },
     {
@@ -260,13 +260,13 @@
       "organization_id": "Q51839131",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842246",
       "role": {
-        "lang:es_LA": "concejal de Ciudad del Este",
-        "lang:en_US": "councillor for the city of Ciudad del Este"
+        "lang:es": "concejal de Ciudad del Este",
+        "lang:en": "councillor for the city of Ciudad del Este"
       }
     },
     {
@@ -276,13 +276,13 @@
       "organization_id": "Q51839131",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842246",
       "role": {
-        "lang:es_LA": "concejal de Ciudad del Este",
-        "lang:en_US": "councillor for the city of Ciudad del Este"
+        "lang:es": "concejal de Ciudad del Este",
+        "lang:en": "councillor for the city of Ciudad del Este"
       }
     },
     {
@@ -292,13 +292,13 @@
       "organization_id": "Q51839131",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:es_LA": "concejal",
-        "lang:en_US": "councillor"
+        "lang:es": "concejal",
+        "lang:en": "councillor"
       },
       "role_code": "Q51842246",
       "role": {
-        "lang:es_LA": "concejal de Ciudad del Este",
-        "lang:en_US": "councillor for the city of Ciudad del Este"
+        "lang:es": "concejal de Ciudad del Este",
+        "lang:en": "councillor for the city of Ciudad del Este"
       }
     }
   ]


### PR DESCRIPTION
This moves this proto-commons- repo to use Wikidata language codes in the generated files, instead of Facebook locale codes, after the change introduced by be979f9 of commons-builder (later fixed in 0e34a06).