### PR TITLE
Boundary lang fix

### DIFF
--- a/boundaries/index.json
+++ b/boundaries/index.json
@@ -9,8 +9,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "name_en",
-      "lang:es_LA": "name_es"
+      "lang:en": "name_en",
+      "lang:es": "name_es"
     }
   },
   {
@@ -23,7 +23,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     }
   },
   {
@@ -40,7 +40,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:alto-paraguay",
@@ -61,7 +61,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:boqueron",
@@ -82,7 +82,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:presidente-hayes",
@@ -103,7 +103,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:concepcion",
@@ -124,7 +124,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:amambay",
@@ -145,7 +145,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:san-pedro",
@@ -166,7 +166,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:canindeyu",
@@ -187,7 +187,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:cordillera",
@@ -208,7 +208,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:caaguazu",
@@ -229,7 +229,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:alto-parana",
@@ -250,7 +250,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:central",
@@ -271,7 +271,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:paraguari",
@@ -292,7 +292,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:guaira",
@@ -313,7 +313,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:neembucu",
@@ -334,7 +334,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:misiones",
@@ -355,7 +355,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:caazapa",
@@ -376,7 +376,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:itapua",
@@ -397,7 +397,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/distrito-capital:distrito-capital-de-paraguay",
@@ -414,8 +414,8 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name_es",
-      "lang:en_US": "name_en"
+      "lang:es": "name_es",
+      "lang:en": "name_en"
     }
   },
   {
@@ -432,7 +432,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:py/departamento:alto-parana/distrito:ciudad-del-este",

--- a/executive/Q51833296/current/popolo-m17n.json
+++ b/executive/Q51833296/current/popolo-m17n.json
@@ -807,8 +807,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/executive/Q51833297/current/popolo-m17n.json
+++ b/executive/Q51833297/current/popolo-m17n.json
@@ -74,7 +74,7 @@
         "lang:en": "capital"
       },
       "name": {
-        "lang:es_LA": "Distrito Capital de Paraguay"
+        "lang:es": "Distrito Capital de Paraguay"
       },
       "parent_id": "Q733"
     },
@@ -99,8 +99,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/executive/Q51833299/current/popolo-m17n.json
+++ b/executive/Q51833299/current/popolo-m17n.json
@@ -27,8 +27,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -54,7 +54,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Concepción"
+        "lang:es": "Concepción"
       },
       "parent_id": "Q733"
     }

--- a/executive/Q51833300/current/popolo-m17n.json
+++ b/executive/Q51833300/current/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "San Pedro"
+        "lang:es": "San Pedro"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/executive/Q51833301/current/popolo-m17n.json
+++ b/executive/Q51833301/current/popolo-m17n.json
@@ -73,8 +73,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -100,7 +100,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Cordillera"
+        "lang:es": "Cordillera"
       },
       "parent_id": "Q733"
     }

--- a/executive/Q51833303/current/popolo-m17n.json
+++ b/executive/Q51833303/current/popolo-m17n.json
@@ -70,8 +70,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -97,7 +97,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Guairá"
+        "lang:es": "Guairá"
       },
       "parent_id": "Q733"
     }

--- a/executive/Q51833304/current/popolo-m17n.json
+++ b/executive/Q51833304/current/popolo-m17n.json
@@ -27,8 +27,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -54,7 +54,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Caaguazú"
+        "lang:es": "Caaguazú"
       },
       "parent_id": "Q733"
     }

--- a/executive/Q51833305/current/popolo-m17n.json
+++ b/executive/Q51833305/current/popolo-m17n.json
@@ -27,8 +27,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -54,7 +54,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Caazapá"
+        "lang:es": "Caazapá"
       },
       "parent_id": "Q733"
     }

--- a/executive/Q51833306/current/popolo-m17n.json
+++ b/executive/Q51833306/current/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Itapúa"
+        "lang:es": "Itapúa"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/executive/Q51833313/current/popolo-m17n.json
+++ b/executive/Q51833313/current/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Misiones"
+        "lang:es": "Misiones"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/executive/Q51833314/current/popolo-m17n.json
+++ b/executive/Q51833314/current/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Paraguarí"
+        "lang:es": "Paraguarí"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/executive/Q51833315/current/popolo-m17n.json
+++ b/executive/Q51833315/current/popolo-m17n.json
@@ -74,7 +74,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Alto Paraná"
+        "lang:es": "Alto Paraná"
       },
       "parent_id": "Q733"
     },
@@ -99,8 +99,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/executive/Q51833317/current/popolo-m17n.json
+++ b/executive/Q51833317/current/popolo-m17n.json
@@ -74,7 +74,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Central"
+        "lang:es": "Central"
       },
       "parent_id": "Q733"
     },
@@ -99,8 +99,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/executive/Q51833320/current/popolo-m17n.json
+++ b/executive/Q51833320/current/popolo-m17n.json
@@ -27,8 +27,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -54,7 +54,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Ñeembucú"
+        "lang:es": "Ñeembucú"
       },
       "parent_id": "Q733"
     }

--- a/executive/Q51833321/current/popolo-m17n.json
+++ b/executive/Q51833321/current/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Amambay"
+        "lang:es": "Amambay"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/executive/Q51833322/current/popolo-m17n.json
+++ b/executive/Q51833322/current/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Canindeyú"
+        "lang:es": "Canindeyú"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/executive/Q51833324/current/popolo-m17n.json
+++ b/executive/Q51833324/current/popolo-m17n.json
@@ -27,8 +27,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -54,7 +54,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Presidente Hayes"
+        "lang:es": "Presidente Hayes"
       },
       "parent_id": "Q733"
     }

--- a/executive/Q51833325/current/popolo-m17n.json
+++ b/executive/Q51833325/current/popolo-m17n.json
@@ -27,8 +27,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -54,7 +54,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Boquerón"
+        "lang:es": "Boquerón"
       },
       "parent_id": "Q733"
     }

--- a/executive/Q51833333/current/popolo-m17n.json
+++ b/executive/Q51833333/current/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Alto Paraguay"
+        "lang:es": "Alto Paraguay"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/executive/Q51885159/current/popolo-m17n.json
+++ b/executive/Q51885159/current/popolo-m17n.json
@@ -73,7 +73,7 @@
         "lang:en": "district of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Ciudad del Este"
+        "lang:es": "Ciudad del Este"
       },
       "parent_id": "Q682654"
     },
@@ -99,7 +99,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Alto Paraná"
+        "lang:es": "Alto Paraná"
       },
       "parent_id": "Q733"
     },
@@ -124,8 +124,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q2119404/Q51884479/popolo-m17n.json
+++ b/legislative/Q2119404/Q51884479/popolo-m17n.json
@@ -186,8 +186,8 @@
         "lang:en": "Constituency of the Senate of Paraguay"
       },
       "name": {
-        "lang:es_LA": "circunscripción nacional",
-        "lang:en_US": "national constituency"
+        "lang:es": "circunscripción nacional",
+        "lang:en": "national constituency"
       },
       "parent_id": "Q733"
     },
@@ -212,8 +212,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q320290/Q51884478/popolo-m17n.json
+++ b/legislative/Q320290/Q51884478/popolo-m17n.json
@@ -158,7 +158,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Distrito Capital de Paraguay"
+        "lang:es": "Distrito Capital de Paraguay"
       },
       "parent_id": "Q733"
     },
@@ -181,7 +181,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Concepción"
+        "lang:es": "Concepción"
       },
       "parent_id": "Q733"
     },
@@ -204,7 +204,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "San Pedro"
+        "lang:es": "San Pedro"
       },
       "parent_id": "Q733"
     },
@@ -227,7 +227,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Cordillera"
+        "lang:es": "Cordillera"
       },
       "parent_id": "Q733"
     },
@@ -250,7 +250,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Guairá"
+        "lang:es": "Guairá"
       },
       "parent_id": "Q733"
     },
@@ -273,7 +273,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Caaguazú"
+        "lang:es": "Caaguazú"
       },
       "parent_id": "Q733"
     },
@@ -296,7 +296,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Caazapá"
+        "lang:es": "Caazapá"
       },
       "parent_id": "Q733"
     },
@@ -319,7 +319,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Itapúa"
+        "lang:es": "Itapúa"
       },
       "parent_id": "Q733"
     },
@@ -342,7 +342,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Misiones"
+        "lang:es": "Misiones"
       },
       "parent_id": "Q733"
     },
@@ -365,7 +365,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Paraguarí"
+        "lang:es": "Paraguarí"
       },
       "parent_id": "Q733"
     },
@@ -388,7 +388,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Alto Paraná"
+        "lang:es": "Alto Paraná"
       },
       "parent_id": "Q733"
     },
@@ -411,7 +411,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Departamento Central"
+        "lang:es": "Departamento Central"
       },
       "parent_id": "Q733"
     },
@@ -434,7 +434,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Ñeembucú"
+        "lang:es": "Ñeembucú"
       },
       "parent_id": "Q733"
     },
@@ -457,7 +457,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Amambay"
+        "lang:es": "Amambay"
       },
       "parent_id": "Q733"
     },
@@ -480,7 +480,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Canindeyú"
+        "lang:es": "Canindeyú"
       },
       "parent_id": "Q733"
     },
@@ -503,7 +503,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Presidente Hayes"
+        "lang:es": "Presidente Hayes"
       },
       "parent_id": "Q733"
     },
@@ -526,7 +526,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Boquerón"
+        "lang:es": "Boquerón"
       },
       "parent_id": "Q733"
     },
@@ -549,7 +549,7 @@
         "lang:en": "constituency of the chamber of deputies of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Alto Paraguay"
+        "lang:es": "Alto Paraguay"
       },
       "parent_id": "Q733"
     },
@@ -574,8 +574,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q51839097/Q51884480/popolo-m17n.json
+++ b/legislative/Q51839097/Q51884480/popolo-m17n.json
@@ -27,8 +27,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -54,7 +54,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Concepción"
+        "lang:es": "Concepción"
       },
       "parent_id": "Q733"
     }

--- a/legislative/Q51839098/Q51884481/popolo-m17n.json
+++ b/legislative/Q51839098/Q51884481/popolo-m17n.json
@@ -77,7 +77,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "San Pedro"
+        "lang:es": "San Pedro"
       },
       "parent_id": "Q733"
     },
@@ -102,8 +102,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q51839099/Q51884482/popolo-m17n.json
+++ b/legislative/Q51839099/Q51884482/popolo-m17n.json
@@ -73,8 +73,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -100,7 +100,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Cordillera"
+        "lang:es": "Cordillera"
       },
       "parent_id": "Q733"
     }

--- a/legislative/Q51839100/Q51884483/popolo-m17n.json
+++ b/legislative/Q51839100/Q51884483/popolo-m17n.json
@@ -73,8 +73,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -100,7 +100,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Guairá"
+        "lang:es": "Guairá"
       },
       "parent_id": "Q733"
     }

--- a/legislative/Q51839101/Q51884484/popolo-m17n.json
+++ b/legislative/Q51839101/Q51884484/popolo-m17n.json
@@ -27,8 +27,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -54,7 +54,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Caaguazú"
+        "lang:es": "Caaguazú"
       },
       "parent_id": "Q733"
     }

--- a/legislative/Q51839102/Q51884485/popolo-m17n.json
+++ b/legislative/Q51839102/Q51884485/popolo-m17n.json
@@ -27,8 +27,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -54,7 +54,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Caazapá"
+        "lang:es": "Caazapá"
       },
       "parent_id": "Q733"
     }

--- a/legislative/Q51839103/Q51884486/popolo-m17n.json
+++ b/legislative/Q51839103/Q51884486/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Itapúa"
+        "lang:es": "Itapúa"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q51839104/Q51884488/popolo-m17n.json
+++ b/legislative/Q51839104/Q51884488/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Misiones"
+        "lang:es": "Misiones"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q51839107/Q51884489/popolo-m17n.json
+++ b/legislative/Q51839107/Q51884489/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Paraguarí"
+        "lang:es": "Paraguarí"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q51839114/Q51884490/popolo-m17n.json
+++ b/legislative/Q51839114/Q51884490/popolo-m17n.json
@@ -74,7 +74,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Alto Paraná"
+        "lang:es": "Alto Paraná"
       },
       "parent_id": "Q733"
     },
@@ -99,8 +99,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q51839115/Q51884491/popolo-m17n.json
+++ b/legislative/Q51839115/Q51884491/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Central"
+        "lang:es": "Central"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q51839117/Q51884492/popolo-m17n.json
+++ b/legislative/Q51839117/Q51884492/popolo-m17n.json
@@ -27,8 +27,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -54,7 +54,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Ñeembucú"
+        "lang:es": "Ñeembucú"
       },
       "parent_id": "Q733"
     }

--- a/legislative/Q51839118/Q51884493/popolo-m17n.json
+++ b/legislative/Q51839118/Q51884493/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Amambay"
+        "lang:es": "Amambay"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q51839120/Q51884494/popolo-m17n.json
+++ b/legislative/Q51839120/Q51884494/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Canindeyú"
+        "lang:es": "Canindeyú"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q51839121/Q51884495/popolo-m17n.json
+++ b/legislative/Q51839121/Q51884495/popolo-m17n.json
@@ -27,8 +27,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -54,7 +54,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Presidente Hayes"
+        "lang:es": "Presidente Hayes"
       },
       "parent_id": "Q733"
     }

--- a/legislative/Q51839123/Q51884497/popolo-m17n.json
+++ b/legislative/Q51839123/Q51884497/popolo-m17n.json
@@ -27,8 +27,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     },
@@ -54,7 +54,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Boquerón"
+        "lang:es": "Boquerón"
       },
       "parent_id": "Q733"
     }

--- a/legislative/Q51839124/Q51884498/popolo-m17n.json
+++ b/legislative/Q51839124/Q51884498/popolo-m17n.json
@@ -28,7 +28,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Alto Paraguay"
+        "lang:es": "Alto Paraguay"
       },
       "parent_id": "Q733"
     },
@@ -53,8 +53,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q51839125/Q51884499/popolo-m17n.json
+++ b/legislative/Q51839125/Q51884499/popolo-m17n.json
@@ -164,7 +164,7 @@
         "lang:en": "capital"
       },
       "name": {
-        "lang:es_LA": "Distrito Capital de Paraguay"
+        "lang:es": "Distrito Capital de Paraguay"
       },
       "parent_id": "Q733"
     },
@@ -189,8 +189,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }

--- a/legislative/Q51839131/Q51884500/popolo-m17n.json
+++ b/legislative/Q51839131/Q51884500/popolo-m17n.json
@@ -163,7 +163,7 @@
         "lang:en": "district of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Ciudad del Este"
+        "lang:es": "Ciudad del Este"
       },
       "parent_id": "Q682654"
     },
@@ -189,7 +189,7 @@
         "lang:en": "department of Paraguay"
       },
       "name": {
-        "lang:es_LA": "Alto Paraná"
+        "lang:es": "Alto Paraná"
       },
       "parent_id": "Q733"
     },
@@ -214,8 +214,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Republic of Paraguay",
-        "lang:es_LA": "República del Paraguay"
+        "lang:en": "Republic of Paraguay",
+        "lang:es": "República del Paraguay"
       },
       "parent_id": null
     }


### PR DESCRIPTION
I forgot to update `boundaries/index.json` with the new language codes when moving to Wikidata codes in 7e415de, so this fixes that.

This PR also removes two popolo JSON files for date-based terms, as they've been replaced with named terms in the index file and should have been removed before.

Confirmed that none of the old codes are now present in the repo.