### PR TITLE
area_id and position-data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/everypolitician/commons-builder.git
-  revision: 0cba06a671a6ff836a02a9889099045987593ff2
+  revision: 30ee2a42f9b4751efc54dcfe6dc6eecec2093ba8
   specs:
     commons-builder (0.1.0)
       commons-integrity
@@ -10,12 +10,12 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.0)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    commons-integrity (0.1)
+    commons-integrity (0.2)
       activesupport
       json
       require_all
@@ -24,13 +24,13 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.0.1)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
-    liquid (4.0.0)
-    mime-types (3.1)
+    liquid (4.0.1)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2018.0812)
     minitest (5.11.3)
     netrc (0.11.0)
     require_all (2.0.0)

--- a/boundaries/position-data-query-results.json
+++ b/boundaries/position-data-query-results.json
@@ -1,0 +1,1757 @@
+{
+  "head" : {
+    "vars" : [ "position", "position_name_es", "position_name_gn", "position_name_en", "positionType", "adminAreaTypes", "adminArea", "admin_area_es", "admin_area_gn", "admin_area_en", "positionSuperclass", "position_superclass_es", "position_superclass_gn", "position_superclass_en", "body", "body_es", "body_gn", "body_en" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20058559"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "senador de Paraguay"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator of Paraguay"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q6256"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "senador"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2119404"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Cámara de Senadores de Paraguay"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Senate of Paraguay"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20058561"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "diputado de Paraguay"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy of Paraguay"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q6256"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1055894"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "diputado"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "deputy"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q320290"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Cámara de Diputados de Paraguay"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Chamber of Deputies"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831955"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Intendente municipal de Asunción"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Municipal mayor of Asuncion"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048 Q515"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2933"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Asunción"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Asunción"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30185"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "alcalde"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "mayor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833297"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete de Asunción"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of Asuncion"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842212"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Concepción"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for Concepción department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q741009"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Concepción"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore Concepción"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Concepción Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839097"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Concepción"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Concepcion"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842213"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de San Pedro"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for San Pedro department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q526176"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "San Pedro"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore San Pedro"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "San Pedro Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839098"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de San Pedro"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of San Pedro"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842214"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Cordillera"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for Cordillera department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q755121"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Cordillera"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Cordillera"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cordillera Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839099"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Cordillera"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Cordillera"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842216"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Guairá"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for Guairá department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q755116"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Guairá"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Guaira"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Guairá Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839100"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental of Guairá"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Guairá"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842217"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Caaguazú"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for the department of Caaguazú"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q880399"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Caaguazú"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Ka'aguasu"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Caaguazú"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839101"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Caaguazú"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Caaguazu"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842218"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Caazapá"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for the department of Caazapá"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q881839"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Caazapá"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore Ka'asapa"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Caazapá"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839102"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Caazapá"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Caazapa"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842219"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Itapúa"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for the department of Itapúa"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q222564"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Itapúa"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Itapúa"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Itapúa"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839103"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Itapúa"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Itapua"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842220"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Misiones"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for Misiones department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q591194"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Misiones"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Misiones"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Misiones Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839104"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Misiones"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Misiones"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842222"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Paraguarí"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for Paraguarí department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q240014"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguarí"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore Paraguari"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguarí Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839107"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Paraguarí"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Paraguari"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842229"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Alto Paraná"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for Alto Paraná department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q682654"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Alto Paraná"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Alto Parana"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Alto Paraná Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839114"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Alto Paraná"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Alto Parana"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842230"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de departamento Central"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for Central department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q372461"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Departamento Central"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore Central"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Central Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839115"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Central"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Central"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842231"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Ñeembucú"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for Ñeembucú department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q755115"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ñeembucú"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Ñe'ẽmbuku"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ñeembucú Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839117"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Ñeembucú"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Ñeembucú"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842232"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Amambay"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for Amambay department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q686586"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Amambay"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Amambai"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Amambay Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839118"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Amambay"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Amambay"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842235"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Canindeyú"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for the department of Canindeyú"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q279085"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Canindeyú"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Kanindeju"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Canindeyú"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839120"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Canindeyú"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Canindeyú"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842237"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Presidente Hayes"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for Presidente Hayes department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q750551"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Presidente Hayes"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore Presidente Hayes"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Presidente Hayes Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839121"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Presidente Hayes"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Presidente Hayes"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842238"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Boquerón"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for Boquerón department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q741017"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Boquerón"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Boquerón"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Boquerón Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839123"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental of Boquerón"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Boqueron"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842239"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal departamental de Alto Paraguay"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for Alto Paraguay department"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q682642"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Alto Paraguay"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Alto Paraguái"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Alto Paraguay Department"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839124"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "junta departmental de Alto Paraguay"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "departmental board of Alto Paraguay"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842240"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal de Asunción"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for the city of Asunción"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q10864048 Q515"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2933"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Asunción"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Asunción"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839125"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Junta Municipal de Asunción"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Municipal Board of Asuncion"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51842246"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal de Ciudad del Este"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor for the city of Ciudad del Este"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q515"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q192235"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ciudad del Este"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Ciudad del Este"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ciudad del Este"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q708492"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "concejal"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "councillor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51839131"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Junta Municipal de Ciudad del Este"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Municipal Board of Ciudad del Este"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51885152"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "intendente municipal de Ciudad del Este"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "municipal mayor of Ciudad del Este"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q515"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q192235"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ciudad del Este"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Ciudad del Este"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ciudad del Este"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30185"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "alcalde"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "mayor"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51885159"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "gabinete de Ciudad del Este"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "cabinet of Ciudad del Este"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q6256"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "position_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "position_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "position_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q6256"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "admin_area_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "admin_area_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "position_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "body" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "body_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "body_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "position_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      }
+    } ]
+  }
+}

--- a/boundaries/position-data-query-used.rq
+++ b/boundaries/position-data-query-used.rq
@@ -1,0 +1,112 @@
+SELECT DISTINCT
+  ?position ?position_name_es ?position_name_gn ?position_name_en
+  ?positionType
+  ?adminAreaTypes
+  ?adminArea ?admin_area_es ?admin_area_gn ?admin_area_en
+  ?positionSuperclass ?position_superclass_es ?position_superclass_gn ?position_superclass_en
+  ?body ?body_es ?body_gn ?body_en
+WHERE {
+  {
+    SELECT DISTINCT ?adminArea
+                (MIN(?primarySort) AS ?primarySort)
+                (GROUP_CONCAT(DISTINCT REPLACE(STR(?adminAreaType), '^.*/', ''); SEPARATOR=" ") AS ?adminAreaTypes) {
+  {
+    VALUES (?adminArea ?primarySort ?adminAreaType) { (wd:Q733 1 wd:Q6256) }
+  } UNION {
+    # Find regional admin areas of this country (generally FLACSen)
+    ?adminArea wdt:P17 wd:Q733 ;
+          wdt:P31/wdt:P279* wd:Q10864048
+    VALUES (?primarySort ?adminAreaType) { (2 wd:Q10864048) }
+  } UNION {
+    # Find cities or municipalities with populations of over 250k
+    VALUES ?adminAreaType { wd:Q515 wd:Q15284 }
+    ?adminArea wdt:P17 wd:Q733 ;
+       wdt:P31/wdt:P279* ?adminAreaType ;
+       wdt:P1082 ?population .
+    FILTER (?population > 250000)
+    VALUES ?primarySort { 3 }
+  } UNION {
+    VALUES (?adminArea ?primarySort ?adminAreaType) {
+    }
+  }
+
+  # Remove admin areas that have ended
+  FILTER NOT EXISTS { ?adminArea wdt:P582|wdt:P576 ?adminAreaEnd . FILTER (?adminAreaEnd < NOW()) }
+} GROUP BY ?adminArea ORDER BY ?primarySort ?adminArea
+
+  }
+  OPTIONAL {
+  ?position rdfs:label ?position_name_es
+  FILTER(LANG(?position_name_es) = "es")
+}
+
+OPTIONAL {
+  ?position rdfs:label ?position_name_gn
+  FILTER(LANG(?position_name_gn) = "gn")
+}
+
+OPTIONAL {
+  ?position rdfs:label ?position_name_en
+  FILTER(LANG(?position_name_en) = "en")
+}
+
+  ?body wdt:P527|wdt:P2670|wdt:P2388 ?position .
+  MINUS { ?body wdt:P576|wdt:P582 ?bodyEnd . FILTER(?bodyEnd < NOW()) }
+  OPTIONAL {
+  ?body rdfs:label ?body_es
+  FILTER(LANG(?body_es) = "es")
+}
+
+OPTIONAL {
+  ?body rdfs:label ?body_gn
+  FILTER(LANG(?body_gn) = "gn")
+}
+
+OPTIONAL {
+  ?body rdfs:label ?body_en
+  FILTER(LANG(?body_en) = "en")
+}
+
+  ?body wdt:P1001 ?adminArea .
+  OPTIONAL {
+  ?adminArea rdfs:label ?admin_area_es
+  FILTER(LANG(?admin_area_es) = "es")
+}
+
+OPTIONAL {
+  ?adminArea rdfs:label ?admin_area_gn
+  FILTER(LANG(?admin_area_gn) = "gn")
+}
+
+OPTIONAL {
+  ?adminArea rdfs:label ?admin_area_en
+  FILTER(LANG(?admin_area_en) = "en")
+}
+
+  OPTIONAL {
+    # If this position appears to be legislative (it's an subclass* of 'legislator')
+    # populate ?positionType with that:
+    VALUES ?positionType { wd:Q4175034 }
+    ?position wdt:P279* ?positionType
+  }
+  # Add the immediate superclass of the position on its way to legislator, head of
+  # government or president:
+  VALUES ?positionAncestor { wd:Q4175034 wd:Q2285706 wd:Q30461  }
+  ?position wdt:P279 ?positionSuperclass .
+            ?positionSuperclass wdt:P279* ?positionAncestor .
+  OPTIONAL {
+  ?positionSuperclass rdfs:label ?position_superclass_es
+  FILTER(LANG(?position_superclass_es) = "es")
+}
+
+OPTIONAL {
+  ?positionSuperclass rdfs:label ?position_superclass_gn
+  FILTER(LANG(?position_superclass_gn) = "gn")
+}
+
+OPTIONAL {
+  ?positionSuperclass rdfs:label ?position_superclass_en
+  FILTER(LANG(?position_superclass_en) = "en")
+}
+
+} ORDER BY ?position

--- a/boundaries/position-data.json
+++ b/boundaries/position-data.json
@@ -1,0 +1,459 @@
+[
+  {
+    "role_id": "Q20058559",
+    "role_name": {
+      "lang:es": "senador de Paraguay",
+      "lang:en": "senator of Paraguay"
+    },
+    "generic_role_id": "Q15686806",
+    "generic_role_name": {
+      "lang:es": "senador",
+      "lang:en": "senator"
+    },
+    "role_level": "Q6256",
+    "role_type": "Q4175034",
+    "organization_id": "Q2119404",
+    "organization_name": {
+      "lang:es": "Cámara de Senadores de Paraguay",
+      "lang:en": "Senate of Paraguay"
+    }
+  },
+  {
+    "role_id": "Q20058561",
+    "role_name": {
+      "lang:es": "diputado de Paraguay",
+      "lang:en": "deputy of Paraguay"
+    },
+    "generic_role_id": "Q1055894",
+    "generic_role_name": {
+      "lang:es": "diputado",
+      "lang:en": "deputy"
+    },
+    "role_level": "Q6256",
+    "role_type": "Q4175034",
+    "organization_id": "Q320290",
+    "organization_name": {
+      "lang:es": "Cámara de Diputados de Paraguay",
+      "lang:en": "Chamber of Deputies"
+    }
+  },
+  {
+    "role_id": "Q51831955",
+    "role_name": {
+      "lang:es": "Intendente municipal de Asunción",
+      "lang:en": "Municipal mayor of Asuncion"
+    },
+    "generic_role_id": "Q30185",
+    "generic_role_name": {
+      "lang:es": "alcalde",
+      "lang:en": "mayor"
+    },
+    "role_level": "Q10864048 Q515",
+    "role_type": null,
+    "organization_id": "Q51833297",
+    "organization_name": {
+      "lang:es": "Gabinete de Asunción",
+      "lang:en": "Cabinet of Asuncion"
+    }
+  },
+  {
+    "role_id": "Q51842212",
+    "role_name": {
+      "lang:es": "concejal departamental de Concepción",
+      "lang:en": "councillor for Concepción department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839097",
+    "organization_name": {
+      "lang:es": "junta departmental de Concepción",
+      "lang:en": "departmental board of Concepcion"
+    }
+  },
+  {
+    "role_id": "Q51842213",
+    "role_name": {
+      "lang:es": "concejal departamental de San Pedro",
+      "lang:en": "councillor for San Pedro department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839098",
+    "organization_name": {
+      "lang:es": "junta departmental de San Pedro",
+      "lang:en": "departmental board of San Pedro"
+    }
+  },
+  {
+    "role_id": "Q51842214",
+    "role_name": {
+      "lang:es": "concejal departamental de Cordillera",
+      "lang:en": "councillor for Cordillera department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839099",
+    "organization_name": {
+      "lang:es": "junta departmental de Cordillera",
+      "lang:en": "departmental board of Cordillera"
+    }
+  },
+  {
+    "role_id": "Q51842216",
+    "role_name": {
+      "lang:es": "concejal departamental de Guairá",
+      "lang:en": "councillor for Guairá department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839100",
+    "organization_name": {
+      "lang:es": "junta departmental of Guairá",
+      "lang:en": "departmental board of Guairá"
+    }
+  },
+  {
+    "role_id": "Q51842217",
+    "role_name": {
+      "lang:es": "concejal departamental de Caaguazú",
+      "lang:en": "councillor for the department of Caaguazú"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839101",
+    "organization_name": {
+      "lang:es": "junta departmental de Caaguazú",
+      "lang:en": "departmental board of Caaguazu"
+    }
+  },
+  {
+    "role_id": "Q51842218",
+    "role_name": {
+      "lang:es": "concejal departamental de Caazapá",
+      "lang:en": "councillor for the department of Caazapá"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839102",
+    "organization_name": {
+      "lang:es": "junta departmental de Caazapá",
+      "lang:en": "departmental board of Caazapa"
+    }
+  },
+  {
+    "role_id": "Q51842219",
+    "role_name": {
+      "lang:es": "concejal departamental de Itapúa",
+      "lang:en": "councillor for the department of Itapúa"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839103",
+    "organization_name": {
+      "lang:es": "junta departmental de Itapúa",
+      "lang:en": "departmental board of Itapua"
+    }
+  },
+  {
+    "role_id": "Q51842220",
+    "role_name": {
+      "lang:es": "concejal departamental de Misiones",
+      "lang:en": "councillor for Misiones department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839104",
+    "organization_name": {
+      "lang:es": "junta departmental de Misiones",
+      "lang:en": "departmental board of Misiones"
+    }
+  },
+  {
+    "role_id": "Q51842222",
+    "role_name": {
+      "lang:es": "concejal departamental de Paraguarí",
+      "lang:en": "councillor for Paraguarí department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839107",
+    "organization_name": {
+      "lang:es": "junta departmental de Paraguarí",
+      "lang:en": "departmental board of Paraguari"
+    }
+  },
+  {
+    "role_id": "Q51842229",
+    "role_name": {
+      "lang:es": "concejal departamental de Alto Paraná",
+      "lang:en": "councillor for Alto Paraná department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839114",
+    "organization_name": {
+      "lang:es": "junta departmental de Alto Paraná",
+      "lang:en": "departmental board of Alto Parana"
+    }
+  },
+  {
+    "role_id": "Q51842230",
+    "role_name": {
+      "lang:es": "concejal departamental de departamento Central",
+      "lang:en": "councillor for Central department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839115",
+    "organization_name": {
+      "lang:es": "junta departmental de Central",
+      "lang:en": "departmental board of Central"
+    }
+  },
+  {
+    "role_id": "Q51842231",
+    "role_name": {
+      "lang:es": "concejal departamental de Ñeembucú",
+      "lang:en": "councillor for Ñeembucú department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839117",
+    "organization_name": {
+      "lang:es": "junta departmental de Ñeembucú",
+      "lang:en": "departmental board of Ñeembucú"
+    }
+  },
+  {
+    "role_id": "Q51842232",
+    "role_name": {
+      "lang:es": "concejal departamental de Amambay",
+      "lang:en": "councillor for Amambay department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839118",
+    "organization_name": {
+      "lang:es": "junta departmental de Amambay",
+      "lang:en": "departmental board of Amambay"
+    }
+  },
+  {
+    "role_id": "Q51842235",
+    "role_name": {
+      "lang:es": "concejal departamental de Canindeyú",
+      "lang:en": "councillor for the department of Canindeyú"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839120",
+    "organization_name": {
+      "lang:es": "junta departmental de Canindeyú",
+      "lang:en": "departmental board of Canindeyú"
+    }
+  },
+  {
+    "role_id": "Q51842237",
+    "role_name": {
+      "lang:es": "concejal departamental de Presidente Hayes",
+      "lang:en": "councillor for Presidente Hayes department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839121",
+    "organization_name": {
+      "lang:es": "junta departmental de Presidente Hayes",
+      "lang:en": "departmental board of Presidente Hayes"
+    }
+  },
+  {
+    "role_id": "Q51842238",
+    "role_name": {
+      "lang:es": "concejal departamental de Boquerón",
+      "lang:en": "councillor for Boquerón department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839123",
+    "organization_name": {
+      "lang:es": "junta departmental of Boquerón",
+      "lang:en": "departmental board of Boqueron"
+    }
+  },
+  {
+    "role_id": "Q51842239",
+    "role_name": {
+      "lang:es": "concejal departamental de Alto Paraguay",
+      "lang:en": "councillor for Alto Paraguay department"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839124",
+    "organization_name": {
+      "lang:es": "junta departmental de Alto Paraguay",
+      "lang:en": "departmental board of Alto Paraguay"
+    }
+  },
+  {
+    "role_id": "Q51842240",
+    "role_name": {
+      "lang:es": "concejal de Asunción",
+      "lang:en": "councillor for the city of Asunción"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q10864048 Q515",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839125",
+    "organization_name": {
+      "lang:es": "Junta Municipal de Asunción",
+      "lang:en": "Municipal Board of Asuncion"
+    }
+  },
+  {
+    "role_id": "Q51842246",
+    "role_name": {
+      "lang:es": "concejal de Ciudad del Este",
+      "lang:en": "councillor for the city of Ciudad del Este"
+    },
+    "generic_role_id": "Q708492",
+    "generic_role_name": {
+      "lang:es": "concejal",
+      "lang:en": "councillor"
+    },
+    "role_level": "Q515",
+    "role_type": "Q4175034",
+    "organization_id": "Q51839131",
+    "organization_name": {
+      "lang:es": "Junta Municipal de Ciudad del Este",
+      "lang:en": "Municipal Board of Ciudad del Este"
+    }
+  },
+  {
+    "role_id": "Q51885152",
+    "role_name": {
+      "lang:es": "intendente municipal de Ciudad del Este",
+      "lang:en": "municipal mayor of Ciudad del Este"
+    },
+    "generic_role_id": "Q30185",
+    "generic_role_name": {
+      "lang:es": "alcalde",
+      "lang:en": "mayor"
+    },
+    "role_level": "Q515",
+    "role_type": null,
+    "organization_id": "Q51885159",
+    "organization_name": {
+      "lang:es": "gabinete de Ciudad del Este",
+      "lang:en": "cabinet of Ciudad del Este"
+    }
+  },
+  {
+    "role_id": "Q34071",
+    "role_name": {
+      "lang:es": "ExPresidente del Paraguay",
+      "lang:gn": "Tendota Paraguaigua",
+      "lang:en": "President of Paraguay"
+    },
+    "generic_role_id": "Q2285706",
+    "generic_role_name": {
+      "lang:es": "jefe de Gobierno",
+      "lang:en": "head of government"
+    },
+    "role_level": "Q6256",
+    "role_type": null,
+    "organization_id": "Q51833296",
+    "organization_name": {
+      "lang:es": "Ministerios del Poder Ejecutivo",
+      "lang:en": "Ministries of Executive Power"
+    }
+  }
+]

--- a/executive/Q51833296/current/popolo-m17n.json
+++ b/executive/Q51833296/current/popolo-m17n.json
@@ -315,6 +315,26 @@
     },
     {
       "name": {
+        "lang:es": "Mario Abdo Benítez",
+        "lang:gn": "Mario Abdo Benítez",
+        "lang:en": "Mario Abdo Benítez"
+      },
+      "id": "Q48136013",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q48136013"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/MaritoAbdo2018"
+        }
+      ]
+    },
+    {
+      "name": {
         "lang:es": "Eusebio Ayala",
         "lang:gn": "Eusebio Ayala",
         "lang:en": "Eusebio Ayala"
@@ -345,26 +365,6 @@
       ],
       "links": [
 
-      ]
-    },
-    {
-      "name": {
-        "lang:es": "Horacio Cartes",
-        "lang:gn": "Horacio Cartes",
-        "lang:en": "Horacio Cartes"
-      },
-      "id": "Q5901842",
-      "identifiers": [
-        {
-          "scheme": "wikidata",
-          "identifier": "Q5901842"
-        }
-      ],
-      "links": [
-        {
-          "note": "facebook",
-          "url": "https://www.facebook.com/horaciocartesoficial"
-        }
       ]
     },
     {
@@ -820,15 +820,33 @@
       "on_behalf_of_id": "Q6540713",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q150816-6ACDBFD9-CE02-430E-9E41-10B26E8FC678",
+      "person_id": "Q150816",
+      "on_behalf_of_id": "Q6540713",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -839,15 +857,33 @@
       "on_behalf_of_id": "Q6540713",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q150829-E09EF76B-13A1-4406-9BA7-9C548F8ED0EA",
+      "person_id": "Q150829",
+      "on_behalf_of_id": "Q6540713",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -858,15 +894,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1653461-13099F1C-784D-4853-9294-EC17DBE74C9B",
+      "person_id": "Q1653461",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -877,15 +931,33 @@
       "on_behalf_of_id": "Q1477511",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1654212-1275B0B1-8AA5-4EF2-9210-54F703152802",
+      "person_id": "Q1654212",
+      "on_behalf_of_id": "Q1477511",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -896,15 +968,33 @@
       "on_behalf_of_id": "Q6540713",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q1654225-1427A40F-4C2E-44C8-8C1A-945FEA97DDE9",
+      "person_id": "Q1654225",
+      "on_behalf_of_id": "Q6540713",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -915,15 +1005,33 @@
       "on_behalf_of_id": "Q2735114",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2357083-16FD770F-5B8E-4B17-8262-1C4B7C1AF298",
+      "person_id": "Q2357083",
+      "on_behalf_of_id": "Q2735114",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -934,15 +1042,33 @@
       "on_behalf_of_id": "Q6540713",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2357137-52F2C0E3-AF15-4181-B7F3-77E1E2ED9E20",
+      "person_id": "Q2357137",
+      "on_behalf_of_id": "Q6540713",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -952,15 +1078,32 @@
       "person_id": "Q2610334",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q2610334-1A704797-193B-49E4-BD43-7D5D87651DE2",
+      "person_id": "Q2610334",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -971,15 +1114,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q26551-7E684501-AF85-4918-9350-5AF54D6F5DBB",
+      "person_id": "Q26551",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -989,15 +1150,32 @@
       "person_id": "Q26554",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q26554-2BFCBCE9-5FB1-44C9-8422-2DE30E2D52C0",
+      "person_id": "Q26554",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1008,15 +1186,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q376549-66C0039A-AC2C-46DF-9221-85D0A6C78DED",
+      "person_id": "Q376549",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1026,15 +1222,32 @@
       "person_id": "Q37679",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q37679-9624176D-7D9B-4170-B987-1FE20A50D404",
+      "person_id": "Q37679",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1045,15 +1258,70 @@
       "on_behalf_of_id": "Q2735114",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q379670-D25DA434-786E-4AED-8E95-A997DBC03F92",
+      "person_id": "Q379670",
+      "on_behalf_of_id": "Q2735114",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q379670-D25DA434-786E-4AED-8E95-A997DBC03F92",
+      "person_id": "Q379670",
+      "on_behalf_of_id": "Q6540713",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q2285706",
+      "role_superclass": {
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q379670-D25DA434-786E-4AED-8E95-A997DBC03F92",
+      "person_id": "Q379670",
+      "on_behalf_of_id": "Q6540713",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1064,15 +1332,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q387044-349C4749-1B0B-48E6-8698-31919E3C5EC1",
+      "person_id": "Q387044",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1082,15 +1368,32 @@
       "person_id": "Q390026",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q390026-A3D2CF6F-A5F3-48ED-93C1-A18D5EC1A4C1",
+      "person_id": "Q390026",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1100,15 +1403,32 @@
       "person_id": "Q430723",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q430723-A03DF336-4FDC-49F3-BA5E-3F41035CDC31",
+      "person_id": "Q430723",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1119,15 +1439,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q440837-675B0B5A-2121-4D35-B63C-E95BD8DF94A6",
+      "person_id": "Q440837",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1138,15 +1476,72 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q460003-E6C0B603-EB30-4326-930A-DF674F97ABCB",
+      "person_id": "Q460003",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q48136013-5fbbb60c-4046-ed79-8375-39b6ffe71bc1",
+      "person_id": "Q48136013",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "start_date": "2018-08-15",
+      "role_superclass_code": "Q2285706",
+      "role_superclass": {
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q48136013-5fbbb60c-4046-ed79-8375-39b6ffe71bc1",
+      "person_id": "Q48136013",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "start_date": "2018-08-15",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1157,15 +1552,33 @@
       "on_behalf_of_id": "Q2735114",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q559950-E91E268D-9D24-4174-83F1-EE0493CC28C7",
+      "person_id": "Q559950",
+      "on_behalf_of_id": "Q2735114",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1176,15 +1589,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q561554-72B11508-5E3B-4177-9EF9-81EBB22EAD82",
+      "person_id": "Q561554",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1195,15 +1626,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q601657-90EDF0B6-3EFF-4C13-AD90-DE251D3CF335",
+      "person_id": "Q601657",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1214,15 +1663,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q628530-9E4B42FE-EA28-4A82-900F-778ADFA7BBA2",
+      "person_id": "Q628530",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1232,15 +1699,32 @@
       "person_id": "Q730957",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q730957-FFDEC9D8-B800-402B-B6C5-E936967FC8F3",
+      "person_id": "Q730957",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1248,17 +1732,36 @@
     {
       "id": "http://www.wikidata.org/entity/statement/Q738679-32E5A48E-E67E-4C57-9B91-AC9A1A91B37C",
       "person_id": "Q738679",
+      "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q738679-32E5A48E-E67E-4C57-9B91-AC9A1A91B37C",
+      "person_id": "Q738679",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1269,15 +1772,33 @@
       "on_behalf_of_id": "Q2735114",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q860963-C4FB10CA-367C-4B90-A985-47F14099434C",
+      "person_id": "Q860963",
+      "on_behalf_of_id": "Q2735114",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1288,15 +1809,33 @@
       "on_behalf_of_id": "Q6540713",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q860978-640155B2-8C56-4717-9A32-29645D21FD48",
+      "person_id": "Q860978",
+      "on_behalf_of_id": "Q6540713",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1307,15 +1846,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q860983-FF3F8717-F8A1-41E9-9EAF-559433456B09",
+      "person_id": "Q860983",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1326,15 +1883,33 @@
       "on_behalf_of_id": "Q6540713",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q860987-CF8DBD0B-3FB6-446D-8B2C-18FEFCB08688",
+      "person_id": "Q860987",
+      "on_behalf_of_id": "Q6540713",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1345,15 +1920,33 @@
       "on_behalf_of_id": "Q2735114",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q860997-62BA9909-2995-4655-B101-F8CE71A11D37",
+      "person_id": "Q860997",
+      "on_behalf_of_id": "Q2735114",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1364,15 +1957,33 @@
       "on_behalf_of_id": "Q6540713",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q861003-0B77E2F8-3F9F-438F-A61F-AFF8839AC30C",
+      "person_id": "Q861003",
+      "on_behalf_of_id": "Q6540713",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1383,15 +1994,33 @@
       "on_behalf_of_id": "Q6540713",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q861008-F62D4D38-7237-4CBE-9B7A-FDEB2CC0CF70",
+      "person_id": "Q861008",
+      "on_behalf_of_id": "Q6540713",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1402,15 +2031,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q861014-9231AB46-822B-4611-8E2D-3263DE45E797",
+      "person_id": "Q861014",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1421,15 +2068,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q861023-DC8E25C1-3038-4BA2-B154-CF5C50FB86E2",
+      "person_id": "Q861023",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1440,15 +2105,33 @@
       "on_behalf_of_id": "Q2735114",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q861579-8EF7BB34-B6B2-4888-8B78-1A5C622FDCA5",
+      "person_id": "Q861579",
+      "on_behalf_of_id": "Q2735114",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1459,15 +2142,33 @@
       "on_behalf_of_id": "Q2735114",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q861582-5F72F069-6447-4245-83CC-844B129760F8",
+      "person_id": "Q861582",
+      "on_behalf_of_id": "Q2735114",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1478,15 +2179,33 @@
       "on_behalf_of_id": "Q2735114",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q861599-EE19C1BB-03D1-47F7-9701-AF1435E6E1C1",
+      "person_id": "Q861599",
+      "on_behalf_of_id": "Q2735114",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1496,15 +2215,32 @@
       "person_id": "Q887269",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q887269-28A6C5B7-D7F1-4A42-8D76-A8522B6E3474",
+      "person_id": "Q887269",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1515,15 +2251,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q888098-0A5DD114-AC40-44EF-80A6-96595B0AA23A",
+      "person_id": "Q888098",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1533,15 +2287,32 @@
       "person_id": "Q888103",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q888103-1A1E87EB-F665-403C-8290-AEF62CAD7846",
+      "person_id": "Q888103",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1552,15 +2323,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q888249-13529BD1-9760-47D0-8E1D-00B52510D383",
+      "person_id": "Q888249",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1571,15 +2360,33 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
+        "lang:gn": "Tendota Paraguaigua",
+        "lang:en": "President of Paraguay"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q888255-39D839E3-A0C9-4F95-93F6-A98646202B50",
+      "person_id": "Q888255",
+      "on_behalf_of_id": "Q928949",
+      "organization_id": "Q51833296",
+      "area_id": "Q733",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
+      },
+      "role_code": "Q34071",
+      "role": {
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
@@ -1589,35 +2396,32 @@
       "person_id": "Q26560",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "jefe de Gobierno",
+        "lang:en": "head of government"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }
     },
     {
-      "id": "http://www.wikidata.org/entity/statement/q5901842-6b26ba7d-4422-8aea-e0cb-ddd936d7c476",
-      "person_id": "Q5901842",
-      "on_behalf_of_id": "Q928949",
+      "id": "http://www.wikidata.org/entity/statement/q26560-579a3db6-44bd-f376-fa45-06b3706dd0f8",
+      "person_id": "Q26560",
       "organization_id": "Q51833296",
       "area_id": "Q733",
-      "start_date": "2013-08-15",
-      "role_superclass_code": "Q34071",
+      "role_superclass_code": "Q30461",
       "role_superclass": {
-        "lang:es": "Presidente del Paraguay",
-        "lang:gn": "Tendota Paraguaigua",
-        "lang:en": "President of Paraguay"
+        "lang:es": "presidente",
+        "lang:gn": "tendota",
+        "lang:en": "president"
       },
       "role_code": "Q34071",
       "role": {
-        "lang:es": "Presidente del Paraguay",
+        "lang:es": "ExPresidente del Paraguay",
         "lang:gn": "Tendota Paraguaigua",
         "lang:en": "President of Paraguay"
       }

--- a/executive/Q51833296/current/query-results.json
+++ b/executive/Q51833296/current/query-results.json
@@ -4,78 +4,16 @@
   },
   "results" : {
     "bindings" : [ {
-      "party" : {
+      "statement" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6540713"
-      },
-      "party_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Liberal Party"
+        "value" : "http://www.wikidata.org/entity/statement/Q150816-6ACDBFD9-CE02-430E-9E41-10B26E8FC678"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q150816"
       },
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Paraguái"
-      },
-      "district_name_es" : {
+      "name_es" : {
         "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Emiliano González Navero"
       },
@@ -84,34 +22,11 @@
         "type" : "literal",
         "value" : "Emiliano González Navero"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Emiliano González Navero"
       },
-      "org" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
-      },
-      "org_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Ministerios del Poder Ejecutivo"
-      },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q150816-6ACDBFD9-CE02-430E-9E41-10B26E8FC678"
-      },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      }
-    }, {
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6540713"
@@ -121,16 +36,12 @@
         "type" : "literal",
         "value" : "Liberal Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q150829"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -139,8 +50,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -148,42 +59,172 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q150816-6ACDBFD9-CE02-430E-9E41-10B26E8FC678"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q150816"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Emiliano González Navero"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Emiliano González Navero"
       },
       "name_en" : {
         "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Emiliano González Navero"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6540713"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q150829-E09EF76B-13A1-4406-9BA7-9C548F8ED0EA"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q150829"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Benigno Ferreira"
       },
@@ -192,34 +233,217 @@
         "type" : "literal",
         "value" : "Benigno Ferreira"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Benigno Ferreira"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6540713"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q150829-E09EF76B-13A1-4406-9BA7-9C548F8ED0EA"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q150829-E09EF76B-13A1-4406-9BA7-9C548F8ED0EA"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q150829"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Benigno Ferreira"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Benigno Ferreira"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Benigno Ferreira"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6540713"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q1653461-13099F1C-784D-4853-9294-EC17DBE74C9B"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1653461"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Marcos Antonio Morínigo"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Marcos Morínigo"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
@@ -229,16 +453,12 @@
         "type" : "literal",
         "value" : "Colorado Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q1653461"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -247,8 +467,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -256,67 +476,48 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Marcos Morínigo"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Marcos Antonio Morínigo"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q1653461-13099F1C-784D-4853-9294-EC17DBE74C9B"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -328,6 +529,137 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q1653461-13099F1C-784D-4853-9294-EC17DBE74C9B"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1653461"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Marcos Antonio Morínigo"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Marcos Morínigo"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q1654212-1275B0B1-8AA5-4EF2-9210-54F703152802"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1654212"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Rafael Franco"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Rafael Franco"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Rafael Franco"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q1477511"
@@ -337,16 +669,12 @@
         "type" : "literal",
         "value" : "Revolutionary Febrerista Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q1654212"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -355,8 +683,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -364,72 +692,48 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Rafael Franco"
+        "value" : "President of Paraguay"
       },
-      "name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Rafael Franco"
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
       },
-      "name_es" : {
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Rafael Franco"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q1654212-1275B0B1-8AA5-4EF2-9210-54F703152802"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -441,6 +745,142 @@
         "value" : "Partido Revolucionario Febrerista"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q1654212-1275B0B1-8AA5-4EF2-9210-54F703152802"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1654212"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Rafael Franco"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Rafael Franco"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Rafael Franco"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1477511"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Revolutionary Febrerista Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Revolucionario Febrerista"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q1654225-1427A40F-4C2E-44C8-8C1A-945FEA97DDE9"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1654225"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Luis Alberto Riart"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Luis Alberto Riart"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Luis Alberto Riart"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6540713"
@@ -450,16 +890,12 @@
         "type" : "literal",
         "value" : "Liberal Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q1654225"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -468,8 +904,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -477,42 +913,64 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
+        "value" : "jefe de Gobierno"
       },
-      "name_en" : {
+      "role_superclass_en" : {
         "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q1654225-1427A40F-4C2E-44C8-8C1A-945FEA97DDE9"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q1654225"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Luis Alberto Riart"
       },
@@ -521,34 +979,114 @@
         "type" : "literal",
         "value" : "Luis Alberto Riart"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Luis Alberto Riart"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6540713"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q1654225-1427A40F-4C2E-44C8-8C1A-945FEA97DDE9"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2357083-16FD770F-5B8E-4B17-8262-1C4B7C1AF298"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2357083"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "José Patricio Guggiari"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "José Patricio Guggiari"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2735114"
@@ -558,16 +1096,12 @@
         "type" : "literal",
         "value" : "Authentic Radical Liberal Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2357083"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -576,8 +1110,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -585,67 +1119,48 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "José Patricio Guggiari"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "José Patricio Guggiari"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q2357083-16FD770F-5B8E-4B17-8262-1C4B7C1AF298"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -657,6 +1172,137 @@
         "value" : "Partido Liberal Radical Auténtico"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2357083-16FD770F-5B8E-4B17-8262-1C4B7C1AF298"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2357083"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "José Patricio Guggiari"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "José Patricio Guggiari"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2735114"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Authentic Radical Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Liberal Radical Auténtico"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2357137-52F2C0E3-AF15-4181-B7F3-77E1E2ED9E20"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2357137"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Eligio Ayala"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Eligio Ayala"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Eligio Ayala"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6540713"
@@ -666,16 +1312,12 @@
         "type" : "literal",
         "value" : "Liberal Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2357137"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -684,8 +1326,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -693,42 +1335,64 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
+        "value" : "jefe de Gobierno"
       },
-      "name_en" : {
+      "role_superclass_en" : {
         "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2357137-52F2C0E3-AF15-4181-B7F3-77E1E2ED9E20"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2357137"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Eligio Ayala"
       },
@@ -737,44 +1401,26 @@
         "type" : "literal",
         "value" : "Eligio Ayala"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Eligio Ayala"
       },
-      "org" : {
+      "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51833296"
+        "value" : "http://www.wikidata.org/entity/Q6540713"
       },
-      "org_en" : {
+      "party_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Ministries of Executive Power"
-      },
-      "org_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Ministerios del Poder Ejecutivo"
-      },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q2357137-52F2C0E3-AF15-4181-B7F3-77E1E2ED9E20"
-      },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      }
-    }, {
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2610334"
+        "value" : "Liberal Party"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -783,8 +1429,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -792,73 +1438,260 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Cirilo Antonio Rivarola"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Cirilo Antonio Rivarola"
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2610334-1A704797-193B-49E4-BD43-7D5D87651DE2"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2610334"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Cirilo Antonio Rivarola"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cirilo Antonio Rivarola"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q2610334-1A704797-193B-49E4-BD43-7D5D87651DE2"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2610334"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Cirilo Antonio Rivarola"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cirilo Antonio Rivarola"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q376549-66C0039A-AC2C-46DF-9221-85D0A6C78DED"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q376549"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Carlos Wasmosy"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan Carlos Wasmosy"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
@@ -868,16 +1701,12 @@
         "type" : "literal",
         "value" : "Colorado Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q376549"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -886,8 +1715,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -895,67 +1724,48 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Juan Carlos Wasmosy"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Juan Carlos Wasmosy"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q376549-66C0039A-AC2C-46DF-9221-85D0A6C78DED"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -967,6 +1777,137 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q376549-66C0039A-AC2C-46DF-9221-85D0A6C78DED"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q376549"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Carlos Wasmosy"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan Carlos Wasmosy"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q379670-D25DA434-786E-4AED-8E95-A997DBC03F92"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q379670"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "José Félix Estigarribia"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "José Félix Estigarribia"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "José Félix Estigarribia"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2735114"
@@ -976,16 +1917,12 @@
         "type" : "literal",
         "value" : "Authentic Radical Liberal Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q379670"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -994,8 +1931,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1003,72 +1940,48 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "José Félix Estigarribia"
+        "value" : "President of Paraguay"
       },
-      "name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "José Félix Estigarribia"
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
       },
-      "name_es" : {
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "José Félix Estigarribia"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q379670-D25DA434-786E-4AED-8E95-A997DBC03F92"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1080,25 +1993,44 @@
         "value" : "Partido Liberal Radical Auténtico"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q379670-D25DA434-786E-4AED-8E95-A997DBC03F92"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q379670"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "José Félix Estigarribia"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "José Félix Estigarribia"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "José Félix Estigarribia"
+      },
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q928949"
+        "value" : "http://www.wikidata.org/entity/Q6540713"
       },
       "party_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Colorado Party"
-      },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q387044"
+        "value" : "Liberal Party"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1107,8 +2039,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1116,67 +2048,367 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q379670-D25DA434-786E-4AED-8E95-A997DBC03F92"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q379670"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "José Félix Estigarribia"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "José Félix Estigarribia"
       },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Pedro Peña"
+        "value" : "José Félix Estigarribia"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2735114"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Authentic Radical Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Liberal Radical Auténtico"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q379670-D25DA434-786E-4AED-8E95-A997DBC03F92"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q379670"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "José Félix Estigarribia"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "José Félix Estigarribia"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "José Félix Estigarribia"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6540713"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q387044-349C4749-1B0B-48E6-8698-31919E3C5EC1"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q387044"
       },
       "name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Pedro Pablo Peña"
       },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Pedro Peña"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q387044-349C4749-1B0B-48E6-8698-31919E3C5EC1"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1188,194 +2420,24 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q387044-349C4749-1B0B-48E6-8698-31919E3C5EC1"
+      },
       "item" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q390026"
-      },
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Paraguái"
-      },
-      "district_name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Adolfo Saguier"
+        "value" : "http://www.wikidata.org/entity/Q387044"
       },
       "name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Adolfo Saguier"
-      },
-      "org" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
-      },
-      "org_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Ministerios del Poder Ejecutivo"
-      },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q390026-A3D2CF6F-A5F3-48ED-93C1-A18D5EC1A4C1"
-      },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      }
-    }, {
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q430723"
-      },
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Paraguái"
-      },
-      "district_name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
+        "value" : "Pedro Pablo Peña"
       },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Juan José Medina"
+        "value" : "Pedro Peña"
       },
-      "name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Juan José Medina"
-      },
-      "org" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
-      },
-      "org_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Ministerios del Poder Ejecutivo"
-      },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q430723-A03DF336-4FDC-49F3-BA5E-3F41035CDC31"
-      },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      }
-    }, {
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
@@ -1385,16 +2447,12 @@
         "type" : "literal",
         "value" : "Colorado Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q440837"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1403,8 +2461,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1412,67 +2470,522 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q390026-A3D2CF6F-A5F3-48ED-93C1-A18D5EC1A4C1"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q390026"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Adolfo Saguier"
       },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Andrés Rodríguez"
+        "value" : "Adolfo Saguier"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q390026-A3D2CF6F-A5F3-48ED-93C1-A18D5EC1A4C1"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q390026"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Adolfo Saguier"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Adolfo Saguier"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q430723-A03DF336-4FDC-49F3-BA5E-3F41035CDC31"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q430723"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan José Medina"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan José Medina"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q430723-A03DF336-4FDC-49F3-BA5E-3F41035CDC31"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q430723"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan José Medina"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan José Medina"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q440837-675B0B5A-2121-4D35-B63C-E95BD8DF94A6"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q440837"
       },
       "name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Andrés Rodríguez Pedotti"
       },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Andrés Rodríguez"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q440837-675B0B5A-2121-4D35-B63C-E95BD8DF94A6"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1484,6 +2997,24 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q440837-675B0B5A-2121-4D35-B63C-E95BD8DF94A6"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q440837"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Andrés Rodríguez Pedotti"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Andrés Rodríguez"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
@@ -1492,17 +3023,121 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q460003-E6C0B603-EB30-4326-930A-DF674F97ABCB"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q460003"
       },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Raúl Cubas Grau"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Raúl Cubas Grau"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1511,8 +3146,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1520,191 +3155,77 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Raúl Cubas Grau"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Raúl Cubas Grau"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q460003-E6C0B603-EB30-4326-930A-DF674F97ABCB"
       },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "party_name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Partido Colorado"
-      }
-    }, {
-      "party" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2735114"
-      },
-      "party_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Authentic Radical Liberal Party"
-      },
       "item" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q559950"
-      },
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Paraguái"
-      },
-      "district_name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Eusebio Ayala"
-      },
-      "name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Eusebio Ayala"
+        "value" : "http://www.wikidata.org/entity/Q460003"
       },
       "name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Eusebio Ayala"
+        "value" : "Raúl Cubas Grau"
       },
-      "org" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
+      "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Ministries of Executive Power"
+        "value" : "Raúl Cubas Grau"
       },
-      "org_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Ministerios del Poder Ejecutivo"
-      },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q559950-E91E268D-9D24-4174-83F1-EE0493CC28C7"
-      },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "party_name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Partido Liberal Radical Auténtico"
-      }
-    }, {
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
@@ -1714,16 +3235,12 @@
         "type" : "literal",
         "value" : "Colorado Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q561554"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1732,8 +3249,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1741,76 +3258,57 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Emilio Aceval"
+        "value" : "President of Paraguay"
       },
-      "name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Emilio Aceval"
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
       },
-      "name_es" : {
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Emilio Aceval"
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q561554-72B11508-5E3B-4177-9EF9-81EBB22EAD82"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
       },
       "party_name_es" : {
         "xml:lang" : "es",
@@ -1818,6 +3316,29 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q48136013-5fbbb60c-4046-ed79-8375-39b6ffe71bc1"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q48136013"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Mario Abdo Benítez"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Mario Abdo Benítez"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mario Abdo Benítez"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
@@ -1827,16 +3348,12 @@
         "type" : "literal",
         "value" : "Colorado Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q5901842"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1845,8 +3362,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1854,72 +3371,48 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Horacio Cartes"
+        "value" : "President of Paraguay"
       },
-      "name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Horacio Cartes"
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
       },
-      "name_es" : {
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Horacio Cartes"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/q5901842-6b26ba7d-4422-8aea-e0cb-ddd936d7c476"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1933,13 +3426,36 @@
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
         "type" : "literal",
-        "value" : "2013-08-15T00:00:00Z"
+        "value" : "2018-08-15T00:00:00Z"
       },
       "facebook" : {
         "type" : "literal",
-        "value" : "horaciocartesoficial"
+        "value" : "MaritoAbdo2018"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q48136013-5fbbb60c-4046-ed79-8375-39b6ffe71bc1"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q48136013"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Mario Abdo Benítez"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Mario Abdo Benítez"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mario Abdo Benítez"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
@@ -1948,17 +3464,572 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-08-15T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "MaritoAbdo2018"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q559950-E91E268D-9D24-4174-83F1-EE0493CC28C7"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q559950"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Eusebio Ayala"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Eusebio Ayala"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Eusebio Ayala"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2735114"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Authentic Radical Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Liberal Radical Auténtico"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q559950-E91E268D-9D24-4174-83F1-EE0493CC28C7"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q559950"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Eusebio Ayala"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Eusebio Ayala"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Eusebio Ayala"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2735114"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Authentic Radical Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Liberal Radical Auténtico"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q561554-72B11508-5E3B-4177-9EF9-81EBB22EAD82"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q561554"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Emilio Aceval"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Emilio Aceval"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Emilio Aceval"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q561554-72B11508-5E3B-4177-9EF9-81EBB22EAD82"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q561554"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Emilio Aceval"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Emilio Aceval"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Emilio Aceval"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q601657-90EDF0B6-3EFF-4C13-AD90-DE251D3CF335"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q601657"
       },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Tomás Romero Pereira"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Tomás Romero Pereira"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1967,8 +4038,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -1976,67 +4047,48 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Tomás Romero Pereira"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Tomás Romero Pereira"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q601657-90EDF0B6-3EFF-4C13-AD90-DE251D3CF335"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2048,6 +4100,24 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q601657-90EDF0B6-3EFF-4C13-AD90-DE251D3CF335"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q601657"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Tomás Romero Pereira"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Tomás Romero Pereira"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
@@ -2056,70 +4126,98 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q628530-9E4B42FE-EA28-4A82-900F-778ADFA7BBA2"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q628530"
       },
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Paraguái"
-      },
-      "district_name_es" : {
+      "name_es" : {
         "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Juan Manuel Frutos"
       },
@@ -2128,28 +4226,85 @@
         "type" : "literal",
         "value" : "Juan Manuel Frutos"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Juan Manuel Frutos"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q628530-9E4B42FE-EA28-4A82-900F-778ADFA7BBA2"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2161,16 +4316,44 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q628530-9E4B42FE-EA28-4A82-900F-778ADFA7BBA2"
+      },
       "item" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q730957"
+        "value" : "http://www.wikidata.org/entity/Q628530"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Manuel Frutos"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Juan Manuel Frutos"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan Manuel Frutos"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -2179,8 +4362,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -2188,42 +4371,74 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
+        "value" : "presidente"
       },
-      "name_en" : {
+      "role_superclass_en" : {
         "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q730957-FFDEC9D8-B800-402B-B6C5-E936967FC8F3"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q730957"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Cándido Bareiro"
       },
@@ -2232,44 +4447,17 @@
         "type" : "literal",
         "value" : "Cándido Bareiro"
       },
-      "name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Cándido Bareiro"
-      },
-      "org" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
+      "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Ministries of Executive Power"
-      },
-      "org_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Ministerios del Poder Ejecutivo"
-      },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q730957-FFDEC9D8-B800-402B-B6C5-E936967FC8F3"
-      },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      }
-    }, {
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q738679"
+        "value" : "Cándido Bareiro"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -2278,8 +4466,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -2287,92 +4475,397 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Bernardino Caballero"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Bernardino Caballero"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q738679-32E5A48E-E67E-4C57-9B91-AC9A1A91B37C"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q730957-FFDEC9D8-B800-402B-B6C5-E936967FC8F3"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q730957"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Cándido Bareiro"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Cándido Bareiro"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cándido Bareiro"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q738679-32E5A48E-E67E-4C57-9B91-AC9A1A91B37C"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738679"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Bernardino Caballero"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Bernardino Caballero"
+      },
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2735114"
+        "value" : "http://www.wikidata.org/entity/Q928949"
       },
       "party_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Authentic Radical Liberal Party"
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q738679-32E5A48E-E67E-4C57-9B91-AC9A1A91B37C"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738679"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Bernardino Caballero"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Bernardino Caballero"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q860963-C4FB10CA-367C-4B90-A985-47F14099434C"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q860963"
       },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Manuel Gondra"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Manuel Gondra"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2735114"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Authentic Radical Liberal Party"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -2381,8 +4874,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -2390,67 +4883,48 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Manuel Gondra"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Manuel Gondra"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q860963-C4FB10CA-367C-4B90-A985-47F14099434C"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2462,78 +4936,124 @@
         "value" : "Partido Liberal Radical Auténtico"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q860963-C4FB10CA-367C-4B90-A985-47F14099434C"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q860963"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Manuel Gondra"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Manuel Gondra"
+      },
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6540713"
+        "value" : "http://www.wikidata.org/entity/Q2735114"
       },
       "party_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Liberal Party"
+        "value" : "Authentic Radical Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Liberal Radical Auténtico"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q860978-640155B2-8C56-4717-9A32-29645D21FD48"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q860978"
       },
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Paraguái"
-      },
-      "district_name_es" : {
+      "name_es" : {
         "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Cecilio Báez"
       },
@@ -2542,106 +5062,209 @@
         "type" : "literal",
         "value" : "Cecilio Báez"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Cecilio Báez"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6540713"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q860978-640155B2-8C56-4717-9A32-29645D21FD48"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q860978-640155B2-8C56-4717-9A32-29645D21FD48"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q860978"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Cecilio Báez"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Cecilio Báez"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cecilio Báez"
+      },
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q928949"
+        "value" : "http://www.wikidata.org/entity/Q6540713"
       },
       "party_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Colorado Party"
+        "value" : "Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q860983-FF3F8717-F8A1-41E9-9EAF-559433456B09"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q860983"
       },
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Paraguái"
-      },
-      "district_name_es" : {
+      "name_es" : {
         "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Juan Gualberto González"
       },
@@ -2650,28 +5273,85 @@
         "type" : "literal",
         "value" : "Juan Gualberto González"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Juan Gualberto González"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q860983-FF3F8717-F8A1-41E9-9EAF-559433456B09"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2683,25 +5363,152 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q860983-FF3F8717-F8A1-41E9-9EAF-559433456B09"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q860983"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Gualberto González"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Juan Gualberto González"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan Gualberto González"
+      },
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6540713"
+        "value" : "http://www.wikidata.org/entity/Q928949"
       },
       "party_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Liberal Party"
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q860987-CF8DBD0B-3FB6-446D-8B2C-18FEFCB08688"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q860987"
       },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Manuel Franco"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Manuel Franco"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6540713"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Liberal Party"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -2710,8 +5517,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -2719,145 +5526,167 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Manuel Franco"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Manuel Franco"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q860987-CF8DBD0B-3FB6-446D-8B2C-18FEFCB08688"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q860987-CF8DBD0B-3FB6-446D-8B2C-18FEFCB08688"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q860987"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Manuel Franco"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Manuel Franco"
+      },
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2735114"
+        "value" : "http://www.wikidata.org/entity/Q6540713"
       },
       "party_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Authentic Radical Liberal Party"
+        "value" : "Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q860997-62BA9909-2995-4655-B101-F8CE71A11D37"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q860997"
       },
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Paraguái"
-      },
-      "district_name_es" : {
+      "name_es" : {
         "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
         "type" : "literal",
         "value" : "José Pedro Montero"
       },
@@ -2866,28 +5695,85 @@
         "type" : "literal",
         "value" : "José Pedro Montero"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "José Pedro Montero"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2735114"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Authentic Radical Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q860997-62BA9909-2995-4655-B101-F8CE71A11D37"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2899,78 +5785,129 @@
         "value" : "Partido Liberal Radical Auténtico"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q860997-62BA9909-2995-4655-B101-F8CE71A11D37"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q860997"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "José Pedro Montero"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "José Pedro Montero"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "José Pedro Montero"
+      },
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q6540713"
+        "value" : "http://www.wikidata.org/entity/Q2735114"
       },
       "party_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Liberal Party"
+        "value" : "Authentic Radical Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Liberal Radical Auténtico"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861003-0B77E2F8-3F9F-438F-A61F-AFF8839AC30C"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q861003"
       },
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Paraguái"
-      },
-      "district_name_es" : {
+      "name_es" : {
         "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Eduardo Schaerer"
       },
@@ -2979,34 +5916,11 @@
         "type" : "literal",
         "value" : "Eduardo Schaerer"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Eduardo Schaerer"
       },
-      "org" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
-      },
-      "org_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Ministerios del Poder Ejecutivo"
-      },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q861003-0B77E2F8-3F9F-438F-A61F-AFF8839AC30C"
-      },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      }
-    }, {
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q6540713"
@@ -3016,16 +5930,12 @@
         "type" : "literal",
         "value" : "Liberal Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q861008"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3034,8 +5944,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3043,73 +5953,381 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Félix Paiva"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Félix Paiva"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q861008-F62D4D38-7237-4CBE-9B7A-FDEB2CC0CF70"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861003-0B77E2F8-3F9F-438F-A61F-AFF8839AC30C"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q861003"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Eduardo Schaerer"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Eduardo Schaerer"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Eduardo Schaerer"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6540713"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861008-F62D4D38-7237-4CBE-9B7A-FDEB2CC0CF70"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q861008"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Félix Paiva"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Félix Paiva"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6540713"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861008-F62D4D38-7237-4CBE-9B7A-FDEB2CC0CF70"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q861008"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Félix Paiva"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Félix Paiva"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q6540713"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861014-9231AB46-822B-4611-8E2D-3263DE45E797"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q861014"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Bautista Egusquiza"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan Bautista Egusquiza"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
@@ -3119,16 +6337,12 @@
         "type" : "literal",
         "value" : "Colorado Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q861014"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3137,8 +6351,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3146,67 +6360,48 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Juan Bautista Egusquiza"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Juan Bautista Egusquiza"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q861014-9231AB46-822B-4611-8E2D-3263DE45E797"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3218,6 +6413,24 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861014-9231AB46-822B-4611-8E2D-3263DE45E797"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q861014"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Bautista Egusquiza"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan Bautista Egusquiza"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
@@ -3227,16 +6440,12 @@
         "type" : "literal",
         "value" : "Colorado Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q861023"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3245,8 +6454,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3254,42 +6463,74 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
+        "value" : "presidente"
       },
-      "name_en" : {
+      "role_superclass_en" : {
         "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861023-DC8E25C1-3038-4BA2-B154-CF5C50FB86E2"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q861023"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Juan Natalicio González"
       },
@@ -3298,28 +6539,85 @@
         "type" : "literal",
         "value" : "Juan Natalicio González"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Juan Natalicio González"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q861023-DC8E25C1-3038-4BA2-B154-CF5C50FB86E2"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3331,25 +6629,152 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861023-DC8E25C1-3038-4BA2-B154-CF5C50FB86E2"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q861023"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Natalicio González"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Juan Natalicio González"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan Natalicio González"
+      },
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2735114"
+        "value" : "http://www.wikidata.org/entity/Q928949"
       },
       "party_name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Authentic Radical Liberal Party"
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861579-8EF7BB34-B6B2-4888-8B78-1A5C622FDCA5"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q861579"
       },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Bautista Gaona"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan Bautista Gaona"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2735114"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Authentic Radical Liberal Party"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3358,8 +6783,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3367,67 +6792,48 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Juan Bautista Gaona"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Juan Bautista Gaona"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q861579-8EF7BB34-B6B2-4888-8B78-1A5C622FDCA5"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3439,6 +6845,24 @@
         "value" : "Partido Liberal Radical Auténtico"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861579-8EF7BB34-B6B2-4888-8B78-1A5C622FDCA5"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q861579"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Bautista Gaona"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan Bautista Gaona"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2735114"
@@ -3447,106 +6871,106 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Authentic Radical Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Liberal Radical Auténtico"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861582-5F72F069-6447-4245-83CC-844B129760F8"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q861582"
       },
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Paraguái"
-      },
-      "district_name_es" : {
+      "name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
+        "value" : "Liberato Marcial Rojas"
       },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Liberato Marcial Rojas"
       },
-      "name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Liberato Marcial Rojas"
-      },
-      "org" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
-      },
-      "org_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Ministerios del Poder Ejecutivo"
-      },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q861582-5F72F069-6447-4245-83CC-844B129760F8"
-      },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "party_name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Partido Liberal Radical Auténtico"
-      }
-    }, {
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2735114"
@@ -3556,16 +6980,12 @@
         "type" : "literal",
         "value" : "Authentic Radical Liberal Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q861599"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3574,8 +6994,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3583,67 +7003,48 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Albino Jara"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Albino Jara"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q861599-EE19C1BB-03D1-47F7-9701-AF1435E6E1C1"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3655,16 +7056,39 @@
         "value" : "Partido Liberal Radical Auténtico"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861582-5F72F069-6447-4245-83CC-844B129760F8"
+      },
       "item" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q887269"
+        "value" : "http://www.wikidata.org/entity/Q861582"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Liberato Marcial Rojas"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Liberato Marcial Rojas"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2735114"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Authentic Radical Liberal Party"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3673,8 +7097,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3682,92 +7106,299 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Liberal Radical Auténtico"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861599-EE19C1BB-03D1-47F7-9701-AF1435E6E1C1"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q861599"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Albino Jara"
       },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Higinio Moríñigo"
+        "value" : "Albino Jara"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2735114"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Authentic Radical Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Liberal Radical Auténtico"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q861599-EE19C1BB-03D1-47F7-9701-AF1435E6E1C1"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q861599"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Albino Jara"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Albino Jara"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2735114"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Authentic Radical Liberal Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Liberal Radical Auténtico"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q887269-28A6C5B7-D7F1-4A42-8D76-A8522B6E3474"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q887269"
       },
       "name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Higinio Morínigo"
       },
-      "org" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
+      "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Ministries of Executive Power"
-      },
-      "org_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Ministerios del Poder Ejecutivo"
-      },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q887269-28A6C5B7-D7F1-4A42-8D76-A8522B6E3474"
-      },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      }
-    }, {
-      "party" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q928949"
-      },
-      "party_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Colorado Party"
-      },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q888098"
+        "value" : "Higinio Moríñigo"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3776,8 +7407,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3785,67 +7416,240 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q887269-28A6C5B7-D7F1-4A42-8D76-A8522B6E3474"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q887269"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Higinio Morínigo"
       },
       "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Federico Chávez"
+        "value" : "Higinio Moríñigo"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q888098-0A5DD114-AC40-44EF-80A6-96595B0AA23A"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q888098"
       },
       "name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Federico Chaves"
       },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Federico Chávez"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q888098-0A5DD114-AC40-44EF-80A6-96595B0AA23A"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3857,16 +7661,39 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q888098-0A5DD114-AC40-44EF-80A6-96595B0AA23A"
+      },
       "item" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q888103"
+        "value" : "http://www.wikidata.org/entity/Q888098"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Federico Chaves"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Federico Chávez"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3875,8 +7702,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -3884,145 +7711,257 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Mariano Roque Alonzo"
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q888103-1A1E87EB-F665-403C-8290-AEF62CAD7846"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q888103"
       },
       "name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Mariano Roque Alonso"
       },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mariano Roque Alonzo"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q888103-1A1E87EB-F665-403C-8290-AEF62CAD7846"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       }
     }, {
-      "party" : {
+      "statement" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q928949"
+        "value" : "http://www.wikidata.org/entity/statement/Q888103-1A1E87EB-F665-403C-8290-AEF62CAD7846"
       },
-      "party_name_en" : {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q888103"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Mariano Roque Alonso"
+      },
+      "name_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Colorado Party"
+        "value" : "Mariano Roque Alonzo"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q888249-13529BD1-9760-47D0-8E1D-00B52510D383"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q888249"
       },
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Paraguái"
-      },
-      "district_name_es" : {
+      "name_es" : {
         "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Raimundo Rolón"
       },
@@ -4031,28 +7970,85 @@
         "type" : "literal",
         "value" : "Raimundo Rolón"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Raimundo Rolón"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q888249-13529BD1-9760-47D0-8E1D-00B52510D383"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -4064,6 +8060,29 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q888249-13529BD1-9760-47D0-8E1D-00B52510D383"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q888249"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Raimundo Rolón"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Raimundo Rolón"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Raimundo Rolón"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
@@ -4072,70 +8091,98 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q888255-39D839E3-A0C9-4F95-93F6-A98646202B50"
       },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q888255"
       },
-      "district" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Paraguái"
-      },
-      "district_name_es" : {
+      "name_es" : {
         "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Paraguay"
-      },
-      "role" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Felipe Molas López"
       },
@@ -4144,39 +8191,11 @@
         "type" : "literal",
         "value" : "Felipe Molas López"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Felipe Molas López"
       },
-      "org" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
-      },
-      "org_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Ministerios del Poder Ejecutivo"
-      },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q888255-39D839E3-A0C9-4F95-93F6-A98646202B50"
-      },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      },
-      "party_name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Partido Colorado"
-      }
-    }, {
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
@@ -4186,16 +8205,12 @@
         "type" : "literal",
         "value" : "Colorado Party"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q26551"
-      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -4204,8 +8219,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -4213,72 +8228,48 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Salvador Jovellanos"
+        "value" : "President of Paraguay"
       },
-      "name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Salvador Jovellanos"
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
       },
-      "name_es" : {
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Salvador Jovellanos"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q26551-7E684501-AF85-4918-9350-5AF54D6F5DBB"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -4290,16 +8281,44 @@
         "value" : "Partido Colorado"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q888255-39D839E3-A0C9-4F95-93F6-A98646202B50"
+      },
       "item" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q26554"
+        "value" : "http://www.wikidata.org/entity/Q888255"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Felipe Molas López"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Felipe Molas López"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Felipe Molas López"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -4308,8 +8327,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -4317,83 +8336,309 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Higinio Uriarte"
+        "value" : "President of Paraguay"
       },
-      "name_es" : {
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Higinio Uriarte"
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q26551-7E684501-AF85-4918-9350-5AF54D6F5DBB"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q26551"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Salvador Jovellanos"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Salvador Jovellanos"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Salvador Jovellanos"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q26551-7E684501-AF85-4918-9350-5AF54D6F5DBB"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q26551"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Salvador Jovellanos"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Salvador Jovellanos"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Salvador Jovellanos"
+      },
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q928949"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      },
+      "party_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Partido Colorado"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q26554-2BFCBCE9-5FB1-44C9-8422-2DE30E2D52C0"
       },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      }
-    }, {
       "item" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q26560"
+        "value" : "http://www.wikidata.org/entity/Q26554"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Higinio Uriarte"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Higinio Uriarte"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -4402,8 +8647,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -4411,88 +8656,177 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "name_en" : {
+      "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Juan Bautista Gill"
+        "value" : "President of Paraguay"
       },
-      "name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Juan Bautista Gill"
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
       },
-      "name_es" : {
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Juan Bautista Gill"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q26554-2BFCBCE9-5FB1-44C9-8422-2DE30E2D52C0"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q26554"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Higinio Uriarte"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Higinio Uriarte"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/q26560-579a3db6-44bd-f376-fa45-06b3706dd0f8"
       },
-      "org_jurisdiction" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q733"
-      }
-    }, {
       "item" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q37679"
+        "value" : "http://www.wikidata.org/entity/Q26560"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Bautista Gill"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Juan Bautista Gill"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan Bautista Gill"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -4501,8 +8835,8 @@
         "type" : "literal",
         "value" : "Paraguái"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Paraguay"
       },
@@ -4510,42 +8844,163 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q34071"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q34071"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
-      },
-      "role_superclass_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tendota Paraguaigua"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
-      },
-      "role_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "President of Paraguay"
+        "value" : "ExPresidente del Paraguay"
       },
       "role_gn" : {
         "xml:lang" : "gn",
         "type" : "literal",
         "value" : "Tendota Paraguaigua"
       },
-      "role_es" : {
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Presidente del Paraguay"
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/q26560-579a3db6-44bd-f376-fa45-06b3706dd0f8"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q26560"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Bautista Gill"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Juan Bautista Gill"
       },
       "name_en" : {
         "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Juan Bautista Gill"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q37679-9624176D-7D9B-4170-B987-1FE20A50D404"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q37679"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Fulgencio Yegros"
       },
@@ -4554,32 +9009,179 @@
         "type" : "literal",
         "value" : "Fulgencio Yegros"
       },
-      "name_es" : {
-        "xml:lang" : "es",
+      "name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Fulgencio Yegros"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2285706"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "jefe de Gobierno"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833296"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Ministries of Executive Power"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ministerios del Poder Ejecutivo"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q37679-9624176D-7D9B-4170-B987-1FE20A50D404"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q733"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q37679-9624176D-7D9B-4170-B987-1FE20A50D404"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q37679"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Fulgencio Yegros"
+      },
+      "name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Fulgencio Yegros"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Fulgencio Yegros"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguay"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q34071"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "ExPresidente del Paraguay"
+      },
+      "role_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tendota Paraguaigua"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "President of Paraguay"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30461"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "presidente"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "president"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833296"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ministerios del Poder Ejecutivo"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ministries of Executive Power"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q733"
+      },
+      "role_superclass_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "tendota"
       }
     } ]
   }

--- a/executive/Q51833296/current/query-used.rq
+++ b/executive/Q51833296/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q34071 }
-  BIND(wd:Q51833296 AS ?org)
+  VALUES ?role { wd:Q34071 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833296 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833297/current/popolo-m17n.json
+++ b/executive/Q51833297/current/popolo-m17n.json
@@ -112,10 +112,10 @@
       "on_behalf_of_id": "Q1477511",
       "organization_id": "Q51833297",
       "area_id": "Q2933",
-      "role_superclass_code": "Q51831955",
+      "role_superclass_code": "Q30185",
       "role_superclass": {
-        "lang:es": "Intendente municipal de Asunción",
-        "lang:en": "Municipal mayor of Asuncion"
+        "lang:es": "alcalde",
+        "lang:en": "mayor"
       },
       "role_code": "Q51831955",
       "role": {

--- a/executive/Q51833297/current/query-results.json
+++ b/executive/Q51833297/current/query-results.json
@@ -4,30 +4,44 @@
   },
   "results" : {
     "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q10708286-44D49D81-6143-47E7-B4F8-1D1F3AF84693"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q10708286"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Mario Ferreiro"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mario Ferreiro"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q1477511"
-      },
-      "party_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Revolutionary Febrerista Party"
       },
       "party_name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Partido Revolucionario Febrerista"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q10708286"
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Revolutionary Febrerista Party"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2933"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Asunción"
       },
@@ -36,8 +50,8 @@
         "type" : "literal",
         "value" : "Paraguay"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Asunción"
       },
@@ -45,16 +59,7 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51831955"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51831955"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Municipal mayor of Asuncion"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Intendente municipal de Asunción"
@@ -64,46 +69,41 @@
         "type" : "literal",
         "value" : "Municipal mayor of Asuncion"
       },
-      "role_es" : {
+      "facebook" : {
+        "type" : "literal",
+        "value" : "MarioFerreiroSanabria"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30185"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "Intendente municipal de Asunción"
+        "value" : "alcalde"
       },
-      "name_en" : {
+      "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Mario Ferreiro"
-      },
-      "name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Mario Ferreiro"
+        "value" : "mayor"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833297"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Cabinet of Asuncion"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Gabinete de Asunción"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q10708286-44D49D81-6143-47E7-B4F8-1D1F3AF84693"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of Asuncion"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2933"
-      },
-      "facebook" : {
-        "type" : "literal",
-        "value" : "MarioFerreiroSanabria"
       }
     } ]
   }

--- a/executive/Q51833297/current/query-used.rq
+++ b/executive/Q51833297/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831955 }
-  BIND(wd:Q51833297 AS ?org)
+  VALUES ?role { wd:Q51831955 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833297 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833299/current/popolo-m17n.json
+++ b/executive/Q51833299/current/popolo-m17n.json
@@ -1,9 +1,37 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:es": "Edgar López"
+      },
+      "id": "Q56760390",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56760390"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de Concepción",
+        "lang:en": "Cabinet of the Department of Concepcion"
+      },
+      "id": "Q51833299",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833299"
+        }
+      ],
+      "area_id": "Q741009"
+    }
   ],
   "areas": [
     {
@@ -60,6 +88,16 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56760390-A1BF10CB-FC92-4E9D-AED3-D21D3C5BC1FE",
+      "person_id": "Q56760390",
+      "organization_id": "Q51833299",
+      "area_id": "Q741009",
+      "role_code": "Q51831956",
+      "role": {
+        "lang:es": "Gobernador del Departamento de Concepción",
+        "lang:en": "Governor of the Department of Concepcion"
+      }
+    }
   ]
 }

--- a/executive/Q51833299/current/query-results.json
+++ b/executive/Q51833299/current/query-results.json
@@ -3,6 +3,71 @@
     "vars" : [ "statement", "item", "name_es", "name_gn", "name_en", "party", "party_name_es", "party_name_gn", "party_name_en", "district", "district_name_es", "district_name_gn", "district_name_en", "role", "role_es", "role_gn", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_es", "role_superclass_gn", "role_superclass_en", "org", "org_es", "org_gn", "org_en", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56760390-A1BF10CB-FC92-4E9D-AED3-D21D3C5BC1FE"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56760390"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Edgar López"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q741009"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Concepción"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore Concepción"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Concepción Department"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831956"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de Concepción"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Governor of the Department of Concepcion"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833299"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Concepción"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Concepcion"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q741009"
+      }
+    } ]
   }
 }

--- a/executive/Q51833299/current/query-used.rq
+++ b/executive/Q51833299/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831956 }
-  BIND(wd:Q51833299 AS ?org)
+  VALUES ?role { wd:Q51831956 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833299 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833300/current/popolo-m17n.json
+++ b/executive/Q51833300/current/popolo-m17n.json
@@ -1,9 +1,37 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:es": "Carlos Giménez"
+      },
+      "id": "Q56760420",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56760420"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de San Pedro",
+        "lang:en": "Cabinet of the Department of San Pedro"
+      },
+      "id": "Q51833300",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833300"
+        }
+      ],
+      "area_id": "Q526176"
+    }
   ],
   "areas": [
     {
@@ -60,6 +88,16 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56760420-1B4D078C-D730-49DA-9E65-45EB5BED5B78",
+      "person_id": "Q56760420",
+      "organization_id": "Q51833300",
+      "area_id": "Q526176",
+      "role_code": "Q51831957",
+      "role": {
+        "lang:es": "Gobernador del Departamento de San Pedro",
+        "lang:en": "Governor of the Department of San Pedro"
+      }
+    }
   ]
 }

--- a/executive/Q51833300/current/query-results.json
+++ b/executive/Q51833300/current/query-results.json
@@ -3,6 +3,71 @@
     "vars" : [ "statement", "item", "name_es", "name_gn", "name_en", "party", "party_name_es", "party_name_gn", "party_name_en", "district", "district_name_es", "district_name_gn", "district_name_en", "role", "role_es", "role_gn", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_es", "role_superclass_gn", "role_superclass_en", "org", "org_es", "org_gn", "org_en", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56760420-1B4D078C-D730-49DA-9E65-45EB5BED5B78"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56760420"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Carlos Giménez"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q526176"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "San Pedro"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore San Pedro"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "San Pedro Department"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831957"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de San Pedro"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Governor of the Department of San Pedro"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833300"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de San Pedro"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of San Pedro"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q526176"
+      }
+    } ]
   }
 }

--- a/executive/Q51833300/current/query-used.rq
+++ b/executive/Q51833300/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831957 }
-  BIND(wd:Q51833300 AS ?org)
+  VALUES ?role { wd:Q51831957 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833300 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833301/current/popolo-m17n.json
+++ b/executive/Q51833301/current/popolo-m17n.json
@@ -18,6 +18,21 @@
           "url": "https://www.facebook.com/carlosmaria.lopez.5"
         }
       ]
+    },
+    {
+      "name": {
+        "lang:es": "Hugo Fleitas"
+      },
+      "id": "Q56760411",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56760411"
+        }
+      ],
+      "links": [
+
+      ]
     }
   ],
   "organizations": [
@@ -112,11 +127,17 @@
       "on_behalf_of_id": "Q2735114",
       "organization_id": "Q51833301",
       "area_id": "Q755121",
-      "role_superclass_code": "Q51831958",
-      "role_superclass": {
+      "role_code": "Q51831958",
+      "role": {
         "lang:es": "Gobernador del Departamento de Cordillera",
         "lang:en": "Governor of the Department of Cordillera"
-      },
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56760411-92BD94BE-C727-478E-9125-EC444869FC9C",
+      "person_id": "Q56760411",
+      "organization_id": "Q51833301",
+      "area_id": "Q755121",
       "role_code": "Q51831958",
       "role": {
         "lang:es": "Gobernador del Departamento de Cordillera",

--- a/executive/Q51833301/current/query-results.json
+++ b/executive/Q51833301/current/query-results.json
@@ -4,57 +4,62 @@
   },
   "results" : {
     "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q51885482-E060F51D-2821-4859-9AFC-08F31F523B76"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51885482"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Carlos María López"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Carlos María López"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2735114"
-      },
-      "party_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Authentic Radical Liberal Party"
       },
       "party_name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Partido Liberal Radical Auténtico"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51885482"
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Authentic Radical Liberal Party"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q755121"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Cordillera Department"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Cordillera"
       },
       "district_name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Cordillera"
       },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Cordillera"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cordillera Department"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51831958"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51831958"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Governor of the Department of Cordillera"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Gobernador del Departamento de Cordillera"
@@ -64,46 +69,92 @@
         "type" : "literal",
         "value" : "Governor of the Department of Cordillera"
       },
-      "role_es" : {
-        "xml:lang" : "es",
+      "facebook" : {
         "type" : "literal",
-        "value" : "Gobernador del Departamento de Cordillera"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Carlos María López"
-      },
-      "name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Carlos María López"
+        "value" : "carlosmaria.lopez.5"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833301"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Cabinet of the Department of Cordillera"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Gabinete del Departamento de Cordillera"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q51885482-E060F51D-2821-4859-9AFC-08F31F523B76"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Cordillera"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q755121"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56760411-92BD94BE-C727-478E-9125-EC444869FC9C"
       },
-      "facebook" : {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56760411"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
-        "value" : "carlosmaria.lopez.5"
+        "value" : "Hugo Fleitas"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q755121"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Cordillera"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Cordillera"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cordillera Department"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831958"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de Cordillera"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Governor of the Department of Cordillera"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833301"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Cordillera"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Cordillera"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q755121"
       }
     } ]
   }

--- a/executive/Q51833301/current/query-used.rq
+++ b/executive/Q51833301/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831958 }
-  BIND(wd:Q51833301 AS ?org)
+  VALUES ?role { wd:Q51831958 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833301 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833303/current/popolo-m17n.json
+++ b/executive/Q51833303/current/popolo-m17n.json
@@ -15,6 +15,21 @@
       "links": [
 
       ]
+    },
+    {
+      "name": {
+        "lang:es": "Juan Carlos Vera"
+      },
+      "id": "Q56760426",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56760426"
+        }
+      ],
+      "links": [
+
+      ]
     }
   ],
   "organizations": [
@@ -109,11 +124,17 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833303",
       "area_id": "Q755116",
-      "role_superclass_code": "Q51831959",
-      "role_superclass": {
+      "role_code": "Q51831959",
+      "role": {
         "lang:es": "Gobernador del Departamento de Guairá",
         "lang:en": "Governor of the Department of Guairá"
-      },
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56760426-4BF2A766-081C-434C-BDA3-2EEB3D489767",
+      "person_id": "Q56760426",
+      "organization_id": "Q51833303",
+      "area_id": "Q755116",
       "role_code": "Q51831959",
       "role": {
         "lang:es": "Gobernador del Departamento de Guairá",

--- a/executive/Q51833303/current/query-results.json
+++ b/executive/Q51833303/current/query-results.json
@@ -4,57 +4,62 @@
   },
   "results" : {
     "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q51885484-086793D0-9E65-48EB-9CE0-1F526D931F98"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51885484"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Javier Silvera"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Javier Silvera"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
-      },
-      "party_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Colorado Party"
       },
       "party_name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Partido Colorado"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51885484"
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q755116"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Guairá Department"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Guaira"
       },
       "district_name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Guairá"
       },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Guaira"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Guairá Department"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51831959"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51831959"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Governor of the Department of Guairá"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Gobernador del Departamento de Guairá"
@@ -64,38 +69,84 @@
         "type" : "literal",
         "value" : "Governor of the Department of Guairá"
       },
-      "role_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Gobernador del Departamento de Guairá"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Javier Silvera"
-      },
-      "name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Javier Silvera"
-      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833303"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Cabinet of the Department of Guairá"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Gabinete del Departamento de Guairá"
       },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Guairá"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q755116"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q51885484-086793D0-9E65-48EB-9CE0-1F526D931F98"
+        "value" : "http://www.wikidata.org/entity/statement/Q56760426-4BF2A766-081C-434C-BDA3-2EEB3D489767"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56760426"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Carlos Vera"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q755116"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Guairá"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Guaira"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Guairá Department"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831959"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de Guairá"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Governor of the Department of Guairá"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833303"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Guairá"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Guairá"
       },
       "org_jurisdiction" : {
         "type" : "uri",

--- a/executive/Q51833303/current/query-used.rq
+++ b/executive/Q51833303/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831959 }
-  BIND(wd:Q51833303 AS ?org)
+  VALUES ?role { wd:Q51831959 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833303 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833304/current/popolo-m17n.json
+++ b/executive/Q51833304/current/popolo-m17n.json
@@ -3,7 +3,21 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de Caaguazú",
+        "lang:en": "Cabinet of the Department of Caaguazú"
+      },
+      "id": "Q51833304",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833304"
+        }
+      ],
+      "area_id": "Q880399"
+    }
   ],
   "areas": [
     {

--- a/executive/Q51833304/current/query-used.rq
+++ b/executive/Q51833304/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831961 }
-  BIND(wd:Q51833304 AS ?org)
+  VALUES ?role { wd:Q51831961 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833304 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833305/current/popolo-m17n.json
+++ b/executive/Q51833305/current/popolo-m17n.json
@@ -1,9 +1,37 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:es": "Pedro Alejandro Diaz Verón"
+      },
+      "id": "Q56760407",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56760407"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de Caazapá",
+        "lang:en": "Cabinet of the Department of Caazapá"
+      },
+      "id": "Q51833305",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833305"
+        }
+      ],
+      "area_id": "Q881839"
+    }
   ],
   "areas": [
     {
@@ -60,6 +88,27 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56760407-8BCD871A-B757-43FD-8845-35624EEFF9FD",
+      "person_id": "Q56760407",
+      "organization_id": "Q51833305",
+      "area_id": "Q881839",
+      "role_code": "Q51831963",
+      "role": {
+        "lang:es": "Governor of the Department of Caazapá",
+        "lang:en": "Gobernador del Depatamento de Caazapá"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56760407-AD8AB864-86F3-4205-B000-F77D2D3F5182",
+      "person_id": "Q56760407",
+      "organization_id": "Q51833305",
+      "area_id": "Q881839",
+      "role_code": "Q51831963",
+      "role": {
+        "lang:es": "Governor of the Department of Caazapá",
+        "lang:en": "Gobernador del Depatamento de Caazapá"
+      }
+    }
   ]
 }

--- a/executive/Q51833305/current/query-results.json
+++ b/executive/Q51833305/current/query-results.json
@@ -3,6 +3,136 @@
     "vars" : [ "statement", "item", "name_es", "name_gn", "name_en", "party", "party_name_es", "party_name_gn", "party_name_en", "district", "district_name_es", "district_name_gn", "district_name_en", "role", "role_es", "role_gn", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_es", "role_superclass_gn", "role_superclass_en", "org", "org_es", "org_gn", "org_en", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56760407-AD8AB864-86F3-4205-B000-F77D2D3F5182"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56760407"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Pedro Alejandro Diaz Verón"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q881839"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Caazapá"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore Ka'asapa"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Caazapá"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831963"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Governor of the Department of Caazapá"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Gobernador del Depatamento de Caazapá"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833305"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Caazapá"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Caazapá"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q881839"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56760407-8BCD871A-B757-43FD-8845-35624EEFF9FD"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56760407"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Pedro Alejandro Diaz Verón"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q881839"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Caazapá"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore Ka'asapa"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Caazapá"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831963"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Governor of the Department of Caazapá"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Gobernador del Depatamento de Caazapá"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833305"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Caazapá"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Caazapá"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q881839"
+      }
+    } ]
   }
 }

--- a/executive/Q51833305/current/query-used.rq
+++ b/executive/Q51833305/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831963 }
-  BIND(wd:Q51833305 AS ?org)
+  VALUES ?role { wd:Q51831963 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833305 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833306/current/popolo-m17n.json
+++ b/executive/Q51833306/current/popolo-m17n.json
@@ -1,9 +1,37 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:es": "Federico Vergara"
+      },
+      "id": "Q56084891",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56084891"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de Itapúa",
+        "lang:en": "Cabinet of the Department of Itapúa"
+      },
+      "id": "Q51833306",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833306"
+        }
+      ],
+      "area_id": "Q222564"
+    }
   ],
   "areas": [
     {
@@ -60,6 +88,16 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56084891-A1C38793-302F-479C-ADCA-08981843B37F",
+      "person_id": "Q56084891",
+      "organization_id": "Q51833306",
+      "area_id": "Q222564",
+      "role_code": "Q51831964",
+      "role": {
+        "lang:es": "Gobernador del Departamento de Itapúa",
+        "lang:en": "Governor of the Department of Itapúa"
+      }
+    }
   ]
 }

--- a/executive/Q51833306/current/query-results.json
+++ b/executive/Q51833306/current/query-results.json
@@ -3,6 +3,71 @@
     "vars" : [ "statement", "item", "name_es", "name_gn", "name_en", "party", "party_name_es", "party_name_gn", "party_name_en", "district", "district_name_es", "district_name_gn", "district_name_en", "role", "role_es", "role_gn", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_es", "role_superclass_gn", "role_superclass_en", "org", "org_es", "org_gn", "org_en", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56084891-A1C38793-302F-479C-ADCA-08981843B37F"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56084891"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Federico Vergara"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q222564"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Itapúa"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Itapúa"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Itapúa"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831964"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de Itapúa"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Governor of the Department of Itapúa"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833306"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Itapúa"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Itapúa"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q222564"
+      }
+    } ]
   }
 }

--- a/executive/Q51833306/current/query-used.rq
+++ b/executive/Q51833306/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831964 }
-  BIND(wd:Q51833306 AS ?org)
+  VALUES ?role { wd:Q51831964 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833306 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833313/current/popolo-m17n.json
+++ b/executive/Q51833313/current/popolo-m17n.json
@@ -1,9 +1,37 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:es": "Carlos Arrechea"
+      },
+      "id": "Q56760432",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56760432"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de Misiones",
+        "lang:en": "Cabinet of the Department of Misiones"
+      },
+      "id": "Q51833313",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833313"
+        }
+      ],
+      "area_id": "Q591194"
+    }
   ],
   "areas": [
     {
@@ -60,6 +88,16 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56760432-E51DF19E-7F8B-498E-B7AB-E8DFE6826964",
+      "person_id": "Q56760432",
+      "organization_id": "Q51833313",
+      "area_id": "Q591194",
+      "role_code": "Q51831965",
+      "role": {
+        "lang:es": "Governor of the Department of Misiones",
+        "lang:en": "Gobernador del Departamento de Misiones"
+      }
+    }
   ]
 }

--- a/executive/Q51833313/current/query-results.json
+++ b/executive/Q51833313/current/query-results.json
@@ -3,6 +3,71 @@
     "vars" : [ "statement", "item", "name_es", "name_gn", "name_en", "party", "party_name_es", "party_name_gn", "party_name_en", "district", "district_name_es", "district_name_gn", "district_name_en", "role", "role_es", "role_gn", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_es", "role_superclass_gn", "role_superclass_en", "org", "org_es", "org_gn", "org_en", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56760432-E51DF19E-7F8B-498E-B7AB-E8DFE6826964"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56760432"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Carlos Arrechea"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q591194"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Misiones"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Misiones"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Misiones Department"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831965"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Governor of the Department of Misiones"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de Misiones"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833313"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Misiones"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Misiones"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q591194"
+      }
+    } ]
   }
 }

--- a/executive/Q51833313/current/query-used.rq
+++ b/executive/Q51833313/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831965 }
-  BIND(wd:Q51833313 AS ?org)
+  VALUES ?role { wd:Q51831965 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833313 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833314/current/popolo-m17n.json
+++ b/executive/Q51833314/current/popolo-m17n.json
@@ -1,9 +1,37 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:es": "Juan Carlos"
+      },
+      "id": "Q56760423",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56760423"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de Paraguarí",
+        "lang:en": "Cabinet of the Department of Paraguari"
+      },
+      "id": "Q51833314",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833314"
+        }
+      ],
+      "area_id": "Q240014"
+    }
   ],
   "areas": [
     {
@@ -60,6 +88,16 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56760423-4A4C114B-D2F3-4D43-9D08-6209B59C8367",
+      "person_id": "Q56760423",
+      "organization_id": "Q51833314",
+      "area_id": "Q240014",
+      "role_code": "Q51831974",
+      "role": {
+        "lang:es": "Gobernador del Departamento de Paraguarí",
+        "lang:en": "Governor of the Department of Paraguari"
+      }
+    }
   ]
 }

--- a/executive/Q51833314/current/query-results.json
+++ b/executive/Q51833314/current/query-results.json
@@ -3,6 +3,71 @@
     "vars" : [ "statement", "item", "name_es", "name_gn", "name_en", "party", "party_name_es", "party_name_gn", "party_name_en", "district", "district_name_es", "district_name_gn", "district_name_en", "role", "role_es", "role_gn", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_es", "role_superclass_gn", "role_superclass_en", "org", "org_es", "org_gn", "org_en", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56760423-4A4C114B-D2F3-4D43-9D08-6209B59C8367"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56760423"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Juan Carlos"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q240014"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Paraguarí"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore Paraguari"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Paraguarí Department"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831974"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de Paraguarí"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Governor of the Department of Paraguari"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833314"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Paraguarí"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Paraguari"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q240014"
+      }
+    } ]
   }
 }

--- a/executive/Q51833314/current/query-used.rq
+++ b/executive/Q51833314/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831974 }
-  BIND(wd:Q51833314 AS ?org)
+  VALUES ?role { wd:Q51831974 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833314 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833315/current/popolo-m17n.json
+++ b/executive/Q51833315/current/popolo-m17n.json
@@ -112,11 +112,6 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833315",
       "area_id": "Q682654",
-      "role_superclass_code": "Q51831976",
-      "role_superclass": {
-        "lang:es": "Gobernador del Departamento de Alto Paraná",
-        "lang:en": "Governor of the Department of Alto Parana"
-      },
       "role_code": "Q51831976",
       "role": {
         "lang:es": "Gobernador del Departamento de Alto Paraná",

--- a/executive/Q51833315/current/query-results.json
+++ b/executive/Q51833315/current/query-results.json
@@ -4,57 +4,62 @@
   },
   "results" : {
     "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q51885483-B160BB46-C613-43C8-A6AE-1EC8146D3515"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51885483"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Fernando Schuster Salinas"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Fernando Schuster Salinas"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
-      },
-      "party_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Colorado Party"
       },
       "party_name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Partido Colorado"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51885483"
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q682654"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Alto Paraná Department"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Alto Parana"
       },
       "district_name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Alto Paraná"
       },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Alto Parana"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Alto Paraná Department"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51831976"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51831976"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Governor of the Department of Alto Parana"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Gobernador del Departamento de Alto Paraná"
@@ -64,46 +69,27 @@
         "type" : "literal",
         "value" : "Governor of the Department of Alto Parana"
       },
-      "role_es" : {
-        "xml:lang" : "es",
+      "facebook" : {
         "type" : "literal",
-        "value" : "Gobernador del Departamento de Alto Paraná"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Fernando Schuster Salinas"
-      },
-      "name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Fernando Schuster Salinas"
+        "value" : "FernandoSchusterOficial"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833315"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Cabinet of the Department of Alto Parana"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Gabinete del Departamento de Alto Paraná"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q51885483-B160BB46-C613-43C8-A6AE-1EC8146D3515"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Alto Parana"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q682654"
-      },
-      "facebook" : {
-        "type" : "literal",
-        "value" : "FernandoSchusterOficial"
       }
     } ]
   }

--- a/executive/Q51833315/current/query-used.rq
+++ b/executive/Q51833315/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831976 }
-  BIND(wd:Q51833315 AS ?org)
+  VALUES ?role { wd:Q51831976 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833315 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833317/current/popolo-m17n.json
+++ b/executive/Q51833317/current/popolo-m17n.json
@@ -18,6 +18,21 @@
           "url": "https://www.facebook.com/carlossaldivargobernador"
         }
       ]
+    },
+    {
+      "name": {
+        "lang:es": "Hugo Javier González"
+      },
+      "id": "Q55669888",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q55669888"
+        }
+      ],
+      "links": [
+
+      ]
     }
   ],
   "organizations": [
@@ -112,11 +127,17 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51833317",
       "area_id": "Q372461",
-      "role_superclass_code": "Q51831977",
-      "role_superclass": {
+      "role_code": "Q51831977",
+      "role": {
         "lang:es": "Gobernador del Departamento Central",
         "lang:en": "Governor of the Department of Central"
-      },
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q55669888-6B762E4E-3694-419E-8A9F-606D897DE4BF",
+      "person_id": "Q55669888",
+      "organization_id": "Q51833317",
+      "area_id": "Q372461",
       "role_code": "Q51831977",
       "role": {
         "lang:es": "Gobernador del Departamento Central",

--- a/executive/Q51833317/current/query-results.json
+++ b/executive/Q51833317/current/query-results.json
@@ -4,57 +4,62 @@
   },
   "results" : {
     "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q51885481-D8103F2F-210E-4A60-B85B-684FE2AE12A8"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51885481"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Carlos Alberto Saldívar"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Carlos Alberto Saldívar"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
-      },
-      "party_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Colorado Party"
       },
       "party_name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Partido Colorado"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51885481"
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q372461"
-      },
-      "district_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Central Department"
-      },
-      "district_name_gn" : {
-        "xml:lang" : "gn",
-        "type" : "literal",
-        "value" : "Tetãvore Central"
       },
       "district_name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Departamento Central"
       },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore Central"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Central Department"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51831977"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51831977"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Governor of the Department of Central"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Gobernador del Departamento Central"
@@ -64,46 +69,92 @@
         "type" : "literal",
         "value" : "Governor of the Department of Central"
       },
-      "role_es" : {
-        "xml:lang" : "es",
+      "facebook" : {
         "type" : "literal",
-        "value" : "Gobernador del Departamento Central"
-      },
-      "name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Carlos Alberto Saldívar"
-      },
-      "name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Carlos Alberto Saldívar"
+        "value" : "carlossaldivargobernador"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51833317"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Cabinet of the Department of Central"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Gabinete del Departamento Central"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q51885481-D8103F2F-210E-4A60-B85B-684FE2AE12A8"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Central"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q372461"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q55669888-6B762E4E-3694-419E-8A9F-606D897DE4BF"
       },
-      "facebook" : {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q55669888"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
-        "value" : "carlossaldivargobernador"
+        "value" : "Hugo Javier González"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q372461"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Departamento Central"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore Central"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Central Department"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831977"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento Central"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Governor of the Department of Central"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833317"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento Central"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Central"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q372461"
       }
     } ]
   }

--- a/executive/Q51833317/current/query-used.rq
+++ b/executive/Q51833317/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831977 }
-  BIND(wd:Q51833317 AS ?org)
+  VALUES ?role { wd:Q51831977 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833317 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833320/current/popolo-m17n.json
+++ b/executive/Q51833320/current/popolo-m17n.json
@@ -1,9 +1,38 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:es": "Carlos Silva",
+        "lang:en": "Carlos Silva"
+      },
+      "id": "Q56084887",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56084887"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de Ñeembucú",
+        "lang:en": "Cabinet of the Department of Ñeembucú"
+      },
+      "id": "Q51833320",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833320"
+        }
+      ],
+      "area_id": "Q755115"
+    }
   ],
   "areas": [
     {
@@ -60,6 +89,16 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56084887-B185919F-DE0D-45B4-99C3-0AC47B3A8198",
+      "person_id": "Q56084887",
+      "organization_id": "Q51833320",
+      "area_id": "Q755115",
+      "role_code": "Q51831978",
+      "role": {
+        "lang:es": "Gobernador del Departamento de Ñeembucú",
+        "lang:en": "Governor of the Department of Ñeembucu"
+      }
+    }
   ]
 }

--- a/executive/Q51833320/current/query-results.json
+++ b/executive/Q51833320/current/query-results.json
@@ -3,6 +3,76 @@
     "vars" : [ "statement", "item", "name_es", "name_gn", "name_en", "party", "party_name_es", "party_name_gn", "party_name_en", "district", "district_name_es", "district_name_gn", "district_name_en", "role", "role_es", "role_gn", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_es", "role_superclass_gn", "role_superclass_en", "org", "org_es", "org_gn", "org_en", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56084887-B185919F-DE0D-45B4-99C3-0AC47B3A8198"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56084887"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Carlos Silva"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Carlos Silva"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q755115"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ñeembucú"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Ñe'ẽmbuku"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ñeembucú Department"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831978"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de Ñeembucú"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Governor of the Department of Ñeembucu"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833320"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Ñeembucú"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Ñeembucú"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q755115"
+      }
+    } ]
   }
 }

--- a/executive/Q51833320/current/query-used.rq
+++ b/executive/Q51833320/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831978 }
-  BIND(wd:Q51833320 AS ?org)
+  VALUES ?role { wd:Q51831978 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833320 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833321/current/popolo-m17n.json
+++ b/executive/Q51833321/current/popolo-m17n.json
@@ -1,9 +1,37 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:es": "Ronald Acevedo"
+      },
+      "id": "Q56479522",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56479522"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de Amambay",
+        "lang:en": "Cabinet of the Department of Amambay"
+      },
+      "id": "Q51833321",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833321"
+        }
+      ],
+      "area_id": "Q686586"
+    }
   ],
   "areas": [
     {
@@ -60,6 +88,16 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56479522-E6758207-8642-49CD-AB1E-58282A302656",
+      "person_id": "Q56479522",
+      "organization_id": "Q51833321",
+      "area_id": "Q686586",
+      "role_code": "Q51831979",
+      "role": {
+        "lang:es": "Gobernador del Departamento de Amambay",
+        "lang:en": "Governor of the Department of Amambay"
+      }
+    }
   ]
 }

--- a/executive/Q51833321/current/query-results.json
+++ b/executive/Q51833321/current/query-results.json
@@ -3,6 +3,71 @@
     "vars" : [ "statement", "item", "name_es", "name_gn", "name_en", "party", "party_name_es", "party_name_gn", "party_name_en", "district", "district_name_es", "district_name_gn", "district_name_en", "role", "role_es", "role_gn", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_es", "role_superclass_gn", "role_superclass_en", "org", "org_es", "org_gn", "org_en", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56479522-E6758207-8642-49CD-AB1E-58282A302656"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56479522"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ronald Acevedo"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q686586"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Amambay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Amambai"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Amambay Department"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831979"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de Amambay"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Governor of the Department of Amambay"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833321"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Amambay"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Amambay"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q686586"
+      }
+    } ]
   }
 }

--- a/executive/Q51833321/current/query-used.rq
+++ b/executive/Q51833321/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831979 }
-  BIND(wd:Q51833321 AS ?org)
+  VALUES ?role { wd:Q51831979 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833321 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833322/current/popolo-m17n.json
+++ b/executive/Q51833322/current/popolo-m17n.json
@@ -1,9 +1,37 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:es": "Cesar Ramírez"
+      },
+      "id": "Q56479523",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56479523"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de Canindeyú",
+        "lang:en": "Cabinet of the Department of Canindeyú"
+      },
+      "id": "Q51833322",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833322"
+        }
+      ],
+      "area_id": "Q279085"
+    }
   ],
   "areas": [
     {
@@ -60,6 +88,16 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56479523-7A6D2C88-C4E2-4522-8EA2-34CC377140D7",
+      "person_id": "Q56479523",
+      "organization_id": "Q51833322",
+      "area_id": "Q279085",
+      "role_code": "Q51831980",
+      "role": {
+        "lang:es": "Gobernador del Departamento de Canindeyú",
+        "lang:en": "Governor of the Department of Canindeyu"
+      }
+    }
   ]
 }

--- a/executive/Q51833322/current/query-results.json
+++ b/executive/Q51833322/current/query-results.json
@@ -3,6 +3,71 @@
     "vars" : [ "statement", "item", "name_es", "name_gn", "name_en", "party", "party_name_es", "party_name_gn", "party_name_en", "district", "district_name_es", "district_name_gn", "district_name_en", "role", "role_es", "role_gn", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_es", "role_superclass_gn", "role_superclass_en", "org", "org_es", "org_gn", "org_en", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56479523-7A6D2C88-C4E2-4522-8EA2-34CC377140D7"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56479523"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Cesar Ramírez"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q279085"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Canindeyú"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Kanindeju"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Canindeyú"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831980"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de Canindeyú"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Governor of the Department of Canindeyu"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833322"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Canindeyú"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Canindeyú"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q279085"
+      }
+    } ]
   }
 }

--- a/executive/Q51833322/current/query-used.rq
+++ b/executive/Q51833322/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831980 }
-  BIND(wd:Q51833322 AS ?org)
+  VALUES ?role { wd:Q51831980 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833322 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833324/current/popolo-m17n.json
+++ b/executive/Q51833324/current/popolo-m17n.json
@@ -1,9 +1,37 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:es": "Antonio Saldivar"
+      },
+      "id": "Q56479525",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56479525"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de Presidente Hayes",
+        "lang:en": "Cabinet of the Department of Presidente Hayes"
+      },
+      "id": "Q51833324",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833324"
+        }
+      ],
+      "area_id": "Q750551"
+    }
   ],
   "areas": [
     {
@@ -60,6 +88,16 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56479525-AEDCAE66-6A8E-4614-8289-2E415D7430E0",
+      "person_id": "Q56479525",
+      "organization_id": "Q51833324",
+      "area_id": "Q750551",
+      "role_code": "Q51831981",
+      "role": {
+        "lang:es": "Gobernador del Departamento de Presidente Hayes",
+        "lang:en": "Governor of the Department of Presidente Hayes"
+      }
+    }
   ]
 }

--- a/executive/Q51833324/current/query-results.json
+++ b/executive/Q51833324/current/query-results.json
@@ -3,6 +3,71 @@
     "vars" : [ "statement", "item", "name_es", "name_gn", "name_en", "party", "party_name_es", "party_name_gn", "party_name_en", "district", "district_name_es", "district_name_gn", "district_name_en", "role", "role_es", "role_gn", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_es", "role_superclass_gn", "role_superclass_en", "org", "org_es", "org_gn", "org_en", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56479525-AEDCAE66-6A8E-4614-8289-2E415D7430E0"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56479525"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Antonio Saldivar"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q750551"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Presidente Hayes"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Tetãvore Presidente Hayes"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Presidente Hayes Department"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831981"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de Presidente Hayes"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Governor of the Department of Presidente Hayes"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833324"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Presidente Hayes"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Presidente Hayes"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q750551"
+      }
+    } ]
   }
 }

--- a/executive/Q51833324/current/query-used.rq
+++ b/executive/Q51833324/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831981 }
-  BIND(wd:Q51833324 AS ?org)
+  VALUES ?role { wd:Q51831981 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833324 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833325/current/popolo-m17n.json
+++ b/executive/Q51833325/current/popolo-m17n.json
@@ -1,9 +1,37 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:es": "Dario Medina"
+      },
+      "id": "Q56760417",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56760417"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de Boquerón",
+        "lang:en": "Cabinet of the Department of Boquerón"
+      },
+      "id": "Q51833325",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833325"
+        }
+      ],
+      "area_id": "Q741017"
+    }
   ],
   "areas": [
     {
@@ -60,6 +88,16 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56760417-8F4E8EC6-7BC7-441D-B553-3A7CA1C58B9B",
+      "person_id": "Q56760417",
+      "organization_id": "Q51833325",
+      "area_id": "Q741017",
+      "role_code": "Q51831983",
+      "role": {
+        "lang:es": "Gobernador del Departamento de Boquerón",
+        "lang:en": "Governor of the Department of Boqueron"
+      }
+    }
   ]
 }

--- a/executive/Q51833325/current/query-results.json
+++ b/executive/Q51833325/current/query-results.json
@@ -3,6 +3,71 @@
     "vars" : [ "statement", "item", "name_es", "name_gn", "name_en", "party", "party_name_es", "party_name_gn", "party_name_en", "district", "district_name_es", "district_name_gn", "district_name_en", "role", "role_es", "role_gn", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_es", "role_superclass_gn", "role_superclass_en", "org", "org_es", "org_gn", "org_en", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56760417-8F4E8EC6-7BC7-441D-B553-3A7CA1C58B9B"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56760417"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Dario Medina"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q741017"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Boquerón"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Boquerón"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Boquerón Department"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831983"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de Boquerón"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Governor of the Department of Boqueron"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833325"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Boquerón"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Boquerón"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q741017"
+      }
+    } ]
   }
 }

--- a/executive/Q51833325/current/query-used.rq
+++ b/executive/Q51833325/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831983 }
-  BIND(wd:Q51833325 AS ?org)
+  VALUES ?role { wd:Q51831983 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833325 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51833333/current/popolo-m17n.json
+++ b/executive/Q51833333/current/popolo-m17n.json
@@ -1,9 +1,37 @@
 {
   "persons": [
+    {
+      "name": {
+        "lang:es": "Mino Adorno"
+      },
+      "id": "Q56760397",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56760397"
+        }
+      ],
+      "links": [
 
+      ]
+    }
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Gabinete del Departamento de Alto Paraguay",
+        "lang:en": "Cabinet of the Department of Alto Paraguay"
+      },
+      "id": "Q51833333",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51833333"
+        }
+      ],
+      "area_id": "Q682642"
+    }
   ],
   "areas": [
     {
@@ -60,6 +88,16 @@
     }
   ],
   "memberships": [
-
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56760397-00924CC0-4429-4C54-9C59-4601850F3746",
+      "person_id": "Q56760397",
+      "organization_id": "Q51833333",
+      "area_id": "Q682642",
+      "role_code": "Q51831986",
+      "role": {
+        "lang:es": "Governor of the Department of Alto Paraguay",
+        "lang:en": "Gobernador del Departamento de Alto Paraguay"
+      }
+    }
   ]
 }

--- a/executive/Q51833333/current/query-results.json
+++ b/executive/Q51833333/current/query-results.json
@@ -3,6 +3,71 @@
     "vars" : [ "statement", "item", "name_es", "name_gn", "name_en", "party", "party_name_es", "party_name_gn", "party_name_en", "district", "district_name_es", "district_name_gn", "district_name_en", "role", "role_es", "role_gn", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_es", "role_superclass_gn", "role_superclass_en", "org", "org_es", "org_gn", "org_en", "org_jurisdiction" ]
   },
   "results" : {
-    "bindings" : [ ]
+    "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56760397-00924CC0-4429-4C54-9C59-4601850F3746"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56760397"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Mino Adorno"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q682642"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Alto Paraguay"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Alto Paraguái"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Alto Paraguay Department"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51831986"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Governor of the Department of Alto Paraguay"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Gobernador del Departamento de Alto Paraguay"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51833333"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Gabinete del Departamento de Alto Paraguay"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Cabinet of the Department of Alto Paraguay"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q682642"
+      }
+    } ]
   }
 }

--- a/executive/Q51833333/current/query-used.rq
+++ b/executive/Q51833333/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51831986 }
-  BIND(wd:Q51833333 AS ?org)
+  VALUES ?role { wd:Q51831986 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51833333 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/Q51885159/current/popolo-m17n.json
+++ b/executive/Q51885159/current/popolo-m17n.json
@@ -18,6 +18,36 @@
           "url": "https://www.facebook.com/SandraZacariasMcLeod"
         }
       ]
+    },
+    {
+      "name": {
+        "lang:es": "Sandra Mcleod Zacarias"
+      },
+      "id": "Q56479529",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56479529"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:es": "Sandra Mcleod Zacarias"
+      },
+      "id": "Q56479530",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q56479530"
+        }
+      ],
+      "links": [
+
+      ]
     }
   ],
   "organizations": [
@@ -137,10 +167,42 @@
       "on_behalf_of_id": "Q928949",
       "organization_id": "Q51885159",
       "area_id": "Q192235",
-      "role_superclass_code": "Q51885152",
+      "role_superclass_code": "Q30185",
       "role_superclass": {
+        "lang:es": "alcalde",
+        "lang:en": "mayor"
+      },
+      "role_code": "Q51885152",
+      "role": {
         "lang:es": "intendente municipal de Ciudad del Este",
         "lang:en": "municipal mayor of Ciudad del Este"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56479529-E6936DC3-8B2F-451A-AC47-7D147D5AC636",
+      "person_id": "Q56479529",
+      "organization_id": "Q51885159",
+      "area_id": "Q192235",
+      "role_superclass_code": "Q30185",
+      "role_superclass": {
+        "lang:es": "alcalde",
+        "lang:en": "mayor"
+      },
+      "role_code": "Q51885152",
+      "role": {
+        "lang:es": "intendente municipal de Ciudad del Este",
+        "lang:en": "municipal mayor of Ciudad del Este"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q56479530-7BCBC3D9-714C-4197-B3F2-F34AE6967764",
+      "person_id": "Q56479530",
+      "organization_id": "Q51885159",
+      "area_id": "Q192235",
+      "role_superclass_code": "Q30185",
+      "role_superclass": {
+        "lang:es": "alcalde",
+        "lang:en": "mayor"
       },
       "role_code": "Q51885152",
       "role": {

--- a/executive/Q51885159/current/query-results.json
+++ b/executive/Q51885159/current/query-results.json
@@ -4,30 +4,44 @@
   },
   "results" : {
     "bindings" : [ {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q51885490-DEC4CD5D-5246-4AE2-8A9B-60D4F7B66BCF"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51885490"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Sandra María McLeod de Zacarías"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Sandra María McLeod de Zacarías"
+      },
       "party" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q928949"
-      },
-      "party_name_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "Colorado Party"
       },
       "party_name_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "Partido Colorado"
       },
-      "item" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51885490"
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Colorado Party"
       },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q192235"
       },
-      "district_name_en" : {
-        "xml:lang" : "en",
+      "district_name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
         "value" : "Ciudad del Este"
       },
@@ -36,8 +50,8 @@
         "type" : "literal",
         "value" : "Ciudad del Este"
       },
-      "district_name_es" : {
-        "xml:lang" : "es",
+      "district_name_en" : {
+        "xml:lang" : "en",
         "type" : "literal",
         "value" : "Ciudad del Este"
       },
@@ -45,16 +59,7 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51885152"
       },
-      "role_superclass" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q51885152"
-      },
-      "role_superclass_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "municipal mayor of Ciudad del Este"
-      },
-      "role_superclass_es" : {
+      "role_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "intendente municipal de Ciudad del Este"
@@ -64,46 +69,199 @@
         "type" : "literal",
         "value" : "municipal mayor of Ciudad del Este"
       },
-      "role_es" : {
+      "facebook" : {
+        "type" : "literal",
+        "value" : "SandraZacariasMcLeod"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30185"
+      },
+      "role_superclass_es" : {
         "xml:lang" : "es",
         "type" : "literal",
-        "value" : "intendente municipal de Ciudad del Este"
+        "value" : "alcalde"
       },
-      "name_en" : {
+      "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Sandra María McLeod de Zacarías"
-      },
-      "name_es" : {
-        "xml:lang" : "es",
-        "type" : "literal",
-        "value" : "Sandra María McLeod de Zacarías"
+        "value" : "mayor"
       },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q51885159"
-      },
-      "org_en" : {
-        "xml:lang" : "en",
-        "type" : "literal",
-        "value" : "cabinet of Ciudad del Este"
       },
       "org_es" : {
         "xml:lang" : "es",
         "type" : "literal",
         "value" : "gabinete de Ciudad del Este"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q51885490-DEC4CD5D-5246-4AE2-8A9B-60D4F7B66BCF"
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "cabinet of Ciudad del Este"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q192235"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56479529-E6936DC3-8B2F-451A-AC47-7D147D5AC636"
       },
-      "facebook" : {
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56479529"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
         "type" : "literal",
-        "value" : "SandraZacariasMcLeod"
+        "value" : "Sandra Mcleod Zacarias"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q192235"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ciudad del Este"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Ciudad del Este"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ciudad del Este"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51885152"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "intendente municipal de Ciudad del Este"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "municipal mayor of Ciudad del Este"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30185"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "alcalde"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "mayor"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51885159"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "gabinete de Ciudad del Este"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "cabinet of Ciudad del Este"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q192235"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q56479530-7BCBC3D9-714C-4197-B3F2-F34AE6967764"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q56479530"
+      },
+      "name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Sandra Mcleod Zacarias"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q192235"
+      },
+      "district_name_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "Ciudad del Este"
+      },
+      "district_name_gn" : {
+        "xml:lang" : "gn",
+        "type" : "literal",
+        "value" : "Ciudad del Este"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Ciudad del Este"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51885152"
+      },
+      "role_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "intendente municipal de Ciudad del Este"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "municipal mayor of Ciudad del Este"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30185"
+      },
+      "role_superclass_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "alcalde"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "mayor"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q51885159"
+      },
+      "org_es" : {
+        "xml:lang" : "es",
+        "type" : "literal",
+        "value" : "gabinete de Ciudad del Este"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "cabinet of Ciudad del Este"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q192235"
       }
     } ]
   }

--- a/executive/Q51885159/current/query-used.rq
+++ b/executive/Q51885159/current/query-used.rq
@@ -1,4 +1,5 @@
-SELECT ?statement
+SELECT DISTINCT
+       ?statement
        ?item ?name_es ?name_gn ?name_en
        ?party ?party_name_es ?party_name_gn ?party_name_en
        ?district ?district_name_es ?district_name_gn ?district_name_en
@@ -7,8 +8,9 @@ SELECT ?statement
        ?role_superclass ?role_superclass_es ?role_superclass_gn ?role_superclass_en
        ?org ?org_es ?org_gn ?org_en ?org_jurisdiction
 WHERE {
-  VALUES ?role_superclass { wd:Q51885152 }
-  BIND(wd:Q51885159 AS ?org)
+  VALUES ?role { wd:Q51885152 }
+  BIND(?role AS ?specific_role) .
+  BIND(wd:Q51885159 AS ?org) .
   OPTIONAL {
   ?org rdfs:label ?org_es
   FILTER(LANG(?org_es) = "es")
@@ -44,7 +46,7 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -60,8 +62,11 @@ OPTIONAL {
   FILTER(LANG(?role_en) = "en")
 }
 
-  ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+    VALUES ?superclass_type { wd:Q2285706 wd:Q30461 }
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279* ?superclass_type .
+    OPTIONAL {
   ?role_superclass rdfs:label ?role_superclass_es
   FILTER(LANG(?role_superclass_es) = "es")
 }
@@ -76,7 +81,9 @@ OPTIONAL {
   FILTER(LANG(?role_superclass_en) = "en")
 }
 
-  ?role wdt:P361 ?org .
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
@@ -95,8 +102,6 @@ OPTIONAL {
 }
 
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
   FILTER(?end_or_sentinel >= NOW())
   # Find any current party membership:
@@ -123,4 +128,4 @@ OPTIONAL {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/executive/index.json
+++ b/executive/index.json
@@ -1,6 +1,7 @@
 [
   {
     "comment": "Ministries of Executive Power",
+    "area_id": "Q733",
     "executive_item_id": "Q51833296",
     "positions": [
       {
@@ -11,6 +12,7 @@
   },
   {
     "comment": "Cabinet of Asuncion",
+    "area_id": "Q2933",
     "executive_item_id": "Q51833297",
     "positions": [
       {
@@ -21,6 +23,7 @@
   },
   {
     "comment": "Cabinet of the Department of Concepcion",
+    "area_id": "Q741009",
     "executive_item_id": "Q51833299",
     "positions": [
       {
@@ -31,6 +34,7 @@
   },
   {
     "comment": "Cabinet of the Department of San Pedro",
+    "area_id": "Q526176",
     "executive_item_id": "Q51833300",
     "positions": [
       {
@@ -41,6 +45,7 @@
   },
   {
     "comment": "Cabinet of the Department of Cordillera",
+    "area_id": "Q755121",
     "executive_item_id": "Q51833301",
     "positions": [
       {
@@ -51,6 +56,7 @@
   },
   {
     "comment": "Cabinet of the Department of Guairá",
+    "area_id": "Q755116",
     "executive_item_id": "Q51833303",
     "positions": [
       {
@@ -61,6 +67,7 @@
   },
   {
     "comment": "Cabinet of the Department of Caaguazú",
+    "area_id": "Q880399",
     "executive_item_id": "Q51833304",
     "positions": [
       {
@@ -71,6 +78,7 @@
   },
   {
     "comment": "Cabinet of the Department of Caazapá",
+    "area_id": "Q881839",
     "executive_item_id": "Q51833305",
     "positions": [
       {
@@ -81,6 +89,7 @@
   },
   {
     "comment": "Cabinet of the Department of Itapúa",
+    "area_id": "Q222564",
     "executive_item_id": "Q51833306",
     "positions": [
       {
@@ -91,6 +100,7 @@
   },
   {
     "comment": "Cabinet of the Department of Misiones",
+    "area_id": "Q591194",
     "executive_item_id": "Q51833313",
     "positions": [
       {
@@ -101,6 +111,7 @@
   },
   {
     "comment": "Cabinet of the Department of Paraguari",
+    "area_id": "Q240014",
     "executive_item_id": "Q51833314",
     "positions": [
       {
@@ -111,6 +122,7 @@
   },
   {
     "comment": "Cabinet of the Department of Alto Parana",
+    "area_id": "Q682654",
     "executive_item_id": "Q51833315",
     "positions": [
       {
@@ -121,6 +133,7 @@
   },
   {
     "comment": "Cabinet of the Department of Central",
+    "area_id": "Q372461",
     "executive_item_id": "Q51833317",
     "positions": [
       {
@@ -131,6 +144,7 @@
   },
   {
     "comment": "Cabinet of the Department of Ñeembucú",
+    "area_id": "Q755115",
     "executive_item_id": "Q51833320",
     "positions": [
       {
@@ -141,6 +155,7 @@
   },
   {
     "comment": "Cabinet of the Department of Amambay",
+    "area_id": "Q686586",
     "executive_item_id": "Q51833321",
     "positions": [
       {
@@ -151,6 +166,7 @@
   },
   {
     "comment": "Cabinet of the Department of Canindeyú",
+    "area_id": "Q279085",
     "executive_item_id": "Q51833322",
     "positions": [
       {
@@ -161,6 +177,7 @@
   },
   {
     "comment": "Cabinet of the Department of Presidente Hayes",
+    "area_id": "Q750551",
     "executive_item_id": "Q51833324",
     "positions": [
       {
@@ -171,6 +188,7 @@
   },
   {
     "comment": "Cabinet of the Department of Boquerón",
+    "area_id": "Q741017",
     "executive_item_id": "Q51833325",
     "positions": [
       {
@@ -181,6 +199,7 @@
   },
   {
     "comment": "Cabinet of the Department of Alto Paraguay",
+    "area_id": "Q682642",
     "executive_item_id": "Q51833333",
     "positions": [
       {
@@ -191,6 +210,7 @@
   },
   {
     "comment": "cabinet of Ciudad del Este",
+    "area_id": "Q192235",
     "executive_item_id": "Q51885159",
     "positions": [
       {

--- a/legislative/Q2119404/Q55647713/popolo-m17n.json
+++ b/legislative/Q2119404/Q55647713/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Cámara de Senadores de Paraguay",
+        "lang:en": "Senate of Paraguay"
+      },
+      "id": "Q2119404",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2119404"
+        }
+      ],
+      "area_id": "Q733",
+      "seat_counts": {
+        "Q20058559": "45"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q2119404/Q55647713/query-used.rq
+++ b/legislative/Q2119404/Q55647713/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q55647713 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q55647713 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q55647713 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q55647713 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q320290/Q55647713/popolo-m17n.json
+++ b/legislative/Q320290/Q55647713/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "Cámara de Diputados de Paraguay",
+        "lang:en": "Chamber of Deputies"
+      },
+      "id": "Q320290",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q320290"
+        }
+      ],
+      "area_id": "Q733",
+      "seat_counts": {
+        "Q20058561": "80"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q320290/Q55647713/query-used.rq
+++ b/legislative/Q320290/Q55647713/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q55647713 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q55647713 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q55647713 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q55647713 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839097/Q51884480/popolo-m17n.json
+++ b/legislative/Q51839097/Q51884480/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental de Concepción",
+        "lang:en": "departmental board of Concepcion"
+      },
+      "id": "Q51839097",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839097"
+        }
+      ],
+      "area_id": "Q741009",
+      "seat_counts": {
+        "Q51842212": "12"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839097/Q51884480/query-used.rq
+++ b/legislative/Q51839097/Q51884480/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884480 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884480 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884480 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884480 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839098/Q51884481/query-used.rq
+++ b/legislative/Q51839098/Q51884481/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884481 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884481 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884481 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884481 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839099/Q51884482/query-used.rq
+++ b/legislative/Q51839099/Q51884482/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884482 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884482 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884482 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884482 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839100/Q51884483/query-used.rq
+++ b/legislative/Q51839100/Q51884483/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884483 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884483 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884483 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884483 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839101/Q51884484/popolo-m17n.json
+++ b/legislative/Q51839101/Q51884484/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental de Caaguazú",
+        "lang:en": "departmental board of Caaguazu"
+      },
+      "id": "Q51839101",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839101"
+        }
+      ],
+      "area_id": "Q880399",
+      "seat_counts": {
+        "Q51842217": "20"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839101/Q51884484/query-used.rq
+++ b/legislative/Q51839101/Q51884484/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884484 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884484 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884484 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884484 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839102/Q51884485/popolo-m17n.json
+++ b/legislative/Q51839102/Q51884485/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental de Caazapá",
+        "lang:en": "departmental board of Caazapa"
+      },
+      "id": "Q51839102",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839102"
+        }
+      ],
+      "area_id": "Q881839",
+      "seat_counts": {
+        "Q51842218": "11"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839102/Q51884485/query-used.rq
+++ b/legislative/Q51839102/Q51884485/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884485 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884485 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884485 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884485 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839103/Q51884486/popolo-m17n.json
+++ b/legislative/Q51839103/Q51884486/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental de Itapúa",
+        "lang:en": "departmental board of Itapua"
+      },
+      "id": "Q51839103",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839103"
+        }
+      ],
+      "area_id": "Q222564",
+      "seat_counts": {
+        "Q51842219": "21"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839103/Q51884486/query-used.rq
+++ b/legislative/Q51839103/Q51884486/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884486 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884486 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884486 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884486 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839104/Q51884488/popolo-m17n.json
+++ b/legislative/Q51839104/Q51884488/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental de Misiones",
+        "lang:en": "departmental board of Misiones"
+      },
+      "id": "Q51839104",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839104"
+        }
+      ],
+      "area_id": "Q591194",
+      "seat_counts": {
+        "Q51842220": "10"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839104/Q51884488/query-used.rq
+++ b/legislative/Q51839104/Q51884488/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884488 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884488 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884488 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884488 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839107/Q51884489/popolo-m17n.json
+++ b/legislative/Q51839107/Q51884489/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental de Paraguarí",
+        "lang:en": "departmental board of Paraguari"
+      },
+      "id": "Q51839107",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839107"
+        }
+      ],
+      "area_id": "Q240014",
+      "seat_counts": {
+        "Q51842222": "15"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839107/Q51884489/query-used.rq
+++ b/legislative/Q51839107/Q51884489/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884489 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884489 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884489 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884489 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839114/Q51884490/query-used.rq
+++ b/legislative/Q51839114/Q51884490/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884490 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884490 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884490 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884490 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839115/Q51884491/popolo-m17n.json
+++ b/legislative/Q51839115/Q51884491/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental de Central",
+        "lang:en": "departmental board of Central"
+      },
+      "id": "Q51839115",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839115"
+        }
+      ],
+      "area_id": "Q372461",
+      "seat_counts": {
+        "Q51842230": "21"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839115/Q51884491/query-used.rq
+++ b/legislative/Q51839115/Q51884491/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884491 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884491 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884491 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884491 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839117/Q51884492/popolo-m17n.json
+++ b/legislative/Q51839117/Q51884492/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental de Ñeembucú",
+        "lang:en": "departmental board of Ñeembucú"
+      },
+      "id": "Q51839117",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839117"
+        }
+      ],
+      "area_id": "Q755115",
+      "seat_counts": {
+        "Q51842231": "8"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839117/Q51884492/query-used.rq
+++ b/legislative/Q51839117/Q51884492/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884492 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884492 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884492 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884492 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839118/Q51884493/popolo-m17n.json
+++ b/legislative/Q51839118/Q51884493/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental de Amambay",
+        "lang:en": "departmental board of Amambay"
+      },
+      "id": "Q51839118",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839118"
+        }
+      ],
+      "area_id": "Q686586",
+      "seat_counts": {
+        "Q51842232": "9"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839118/Q51884493/query-used.rq
+++ b/legislative/Q51839118/Q51884493/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884493 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884493 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884493 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884493 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839120/Q51884494/popolo-m17n.json
+++ b/legislative/Q51839120/Q51884494/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental de Canindeyú",
+        "lang:en": "departmental board of Canindeyú"
+      },
+      "id": "Q51839120",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839120"
+        }
+      ],
+      "area_id": "Q279085",
+      "seat_counts": {
+        "Q51842235": "10"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839120/Q51884494/query-used.rq
+++ b/legislative/Q51839120/Q51884494/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884494 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884494 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884494 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884494 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839121/Q51884495/popolo-m17n.json
+++ b/legislative/Q51839121/Q51884495/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental de Presidente Hayes",
+        "lang:en": "departmental board of Presidente Hayes"
+      },
+      "id": "Q51839121",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839121"
+        }
+      ],
+      "area_id": "Q750551",
+      "seat_counts": {
+        "Q51842237": "8"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839121/Q51884495/query-used.rq
+++ b/legislative/Q51839121/Q51884495/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884495 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884495 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884495 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884495 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839123/Q51884497/popolo-m17n.json
+++ b/legislative/Q51839123/Q51884497/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental of Boquerón",
+        "lang:en": "departmental board of Boqueron"
+      },
+      "id": "Q51839123",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839123"
+        }
+      ],
+      "area_id": "Q741017",
+      "seat_counts": {
+        "Q51842238": "7"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839123/Q51884497/query-used.rq
+++ b/legislative/Q51839123/Q51884497/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884497 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884497 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884497 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884497 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839124/Q51884498/popolo-m17n.json
+++ b/legislative/Q51839124/Q51884498/popolo-m17n.json
@@ -3,7 +3,24 @@
 
   ],
   "organizations": [
-
+    {
+      "name": {
+        "lang:es": "junta departmental de Alto Paraguay",
+        "lang:en": "departmental board of Alto Paraguay"
+      },
+      "id": "Q51839124",
+      "classification": "branch",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q51839124"
+        }
+      ],
+      "area_id": "Q682642",
+      "seat_counts": {
+        "Q51842239": "7"
+      }
+    }
   ],
   "areas": [
     {

--- a/legislative/Q51839124/Q51884498/query-used.rq
+++ b/legislative/Q51839124/Q51884498/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884498 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884498 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884498 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884498 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839125/Q51884499/query-used.rq
+++ b/legislative/Q51839125/Q51884499/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884499 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884499 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884499 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884499 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/Q51839131/Q51884500/query-used.rq
+++ b/legislative/Q51839131/Q51884500/query-used.rq
@@ -33,6 +33,25 @@ OPTIONAL {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
+  ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL { wd:Q51884500 wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:Q51884500 wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:Q51884500 })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+
   OPTIONAL {
   ?item rdfs:label ?name_es
   FILTER(LANG(?name_es) = "es")
@@ -48,7 +67,6 @@ OPTIONAL {
   FILTER(LANG(?name_en) = "en")
 }
 
-  ?statement ps:P39 ?specific_role .
   OPTIONAL {
   ?role rdfs:label ?role_es
   FILTER(LANG(?role_es) = "es")
@@ -83,9 +101,6 @@ OPTIONAL {
 }
 
   }
-  ?statement pq:P2937 wd:Q51884500 .
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
@@ -124,4 +139,4 @@ OPTIONAL {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   
-} ORDER BY ?item ?role ?term ?start ?end
+} ORDER BY ?item ?role ?term ?start ?end ?role_superclass ?party ?org ?district

--- a/legislative/index-query-used.rq
+++ b/legislative/index-query-used.rq
@@ -33,7 +33,15 @@ SELECT DISTINCT ?legislature ?legislatureLabel ?adminArea ?adminAreaLabel ?admin
 
   VALUES ?legislatureType { wd:Q11204 wd:Q10553309 }
   ?legislature wdt:P31/wdt:P279* ?legislatureType .
-  FILTER (?legislatureType != wd:Q11204 || NOT EXISTS { ?legislature wdt:P527 ?legislaturePart . ?legislaturePart  wdt:P31/wdt:P279* wd:Q10553309 })
+
+  # Exclude legislatures (but never legislative houses) that "has part"
+  # legislative houses or other legislatures. This happens with UK councils
+  # (see e.g. Q17021809).
+  FILTER (?legislatureType != wd:Q11204 || NOT EXISTS {
+    VALUES ?subLegislatureType { wd:Q10553309 wd:Q11204 }
+    ?legislature wdt:P527 ?legislaturePart .
+    ?legislaturePart  wdt:P31/wdt:P279* ?subLegislatureType .
+  })
 
   # Attempt to find the position for members of the legislature
   OPTIONAL {
@@ -45,6 +53,16 @@ SELECT DISTINCT ?legislature ?legislatureLabel ?adminArea ?adminAreaLabel ?admin
       VALUES ?legislaturePostSuperType { wd:Q4175034 wd:Q708492 }
       ?legislaturePost wdt:P279+ ?legislaturePostSuperType .
     }
+    # Some legislatures, e.g. Q633872 have multiple 'has part's pointing at
+    # posts, where one subclasses the other. In this case, we want to only
+    # return the parent, and then consider superclasses in the legislative
+    # membership query, so that we don't end up with duplicate legislature
+    # entries in the legislative index.
+    FILTER NOT EXISTS {
+      ?legislature wdt:P527|wdt:P2670 ?legislaturePostOther .
+      ?legislaturePost wdt:P279+ ?legislaturePostOther .
+    }
+    FILTER NOT EXISTS { ?legislaturePost wdt:P576 ?legislaturePostEnd . FILTER (?legislaturePostEnd < NOW()) }
   }
   OPTIONAL {
     ?legislature wdt:P1342 ?numberOfSeats .

--- a/legislative/index.json
+++ b/legislative/index.json
@@ -2,6 +2,8 @@
   {
     "comment": "Senate of Paraguay",
     "house_item_id": "Q2119404",
+    "seat_count": "45",
+    "area_id": "Q733",
     "position_item_id": "Q20058559",
     "terms": [
       {
@@ -13,6 +15,8 @@
   {
     "comment": "Chamber of Deputies",
     "house_item_id": "Q320290",
+    "seat_count": "80",
+    "area_id": "Q733",
     "position_item_id": "Q20058561",
     "terms": [
       {
@@ -24,6 +28,8 @@
   {
     "comment": "departmental board of Concepcion",
     "house_item_id": "Q51839097",
+    "seat_count": "12",
+    "area_id": "Q741009",
     "position_item_id": "Q51842212",
     "terms": [
       {
@@ -35,6 +41,8 @@
   {
     "comment": "departmental board of San Pedro",
     "house_item_id": "Q51839098",
+    "seat_count": "18",
+    "area_id": "Q526176",
     "position_item_id": "Q51842213",
     "terms": [
       {
@@ -46,6 +54,8 @@
   {
     "comment": "departmental board of Cordillera",
     "house_item_id": "Q51839099",
+    "seat_count": "16",
+    "area_id": "Q755121",
     "position_item_id": "Q51842214",
     "terms": [
       {
@@ -57,6 +67,8 @@
   {
     "comment": "departmental board of Guairá",
     "house_item_id": "Q51839100",
+    "seat_count": "13",
+    "area_id": "Q755116",
     "position_item_id": "Q51842216",
     "terms": [
       {
@@ -68,6 +80,8 @@
   {
     "comment": "departmental board of Caaguazu",
     "house_item_id": "Q51839101",
+    "seat_count": "20",
+    "area_id": "Q880399",
     "position_item_id": "Q51842217",
     "terms": [
       {
@@ -79,6 +93,8 @@
   {
     "comment": "departmental board of Caazapa",
     "house_item_id": "Q51839102",
+    "seat_count": "11",
+    "area_id": "Q881839",
     "position_item_id": "Q51842218",
     "terms": [
       {
@@ -90,6 +106,8 @@
   {
     "comment": "departmental board of Itapua",
     "house_item_id": "Q51839103",
+    "seat_count": "21",
+    "area_id": "Q222564",
     "position_item_id": "Q51842219",
     "terms": [
       {
@@ -101,6 +119,8 @@
   {
     "comment": "departmental board of Misiones",
     "house_item_id": "Q51839104",
+    "seat_count": "10",
+    "area_id": "Q591194",
     "position_item_id": "Q51842220",
     "terms": [
       {
@@ -112,6 +132,8 @@
   {
     "comment": "departmental board of Paraguari",
     "house_item_id": "Q51839107",
+    "seat_count": "15",
+    "area_id": "Q240014",
     "position_item_id": "Q51842222",
     "terms": [
       {
@@ -123,6 +145,8 @@
   {
     "comment": "departmental board of Alto Parana",
     "house_item_id": "Q51839114",
+    "seat_count": "21",
+    "area_id": "Q682654",
     "position_item_id": "Q51842229",
     "terms": [
       {
@@ -134,6 +158,8 @@
   {
     "comment": "departmental board of Central",
     "house_item_id": "Q51839115",
+    "seat_count": "21",
+    "area_id": "Q372461",
     "position_item_id": "Q51842230",
     "terms": [
       {
@@ -145,6 +171,8 @@
   {
     "comment": "departmental board of Ñeembucú",
     "house_item_id": "Q51839117",
+    "seat_count": "8",
+    "area_id": "Q755115",
     "position_item_id": "Q51842231",
     "terms": [
       {
@@ -156,6 +184,8 @@
   {
     "comment": "departmental board of Amambay",
     "house_item_id": "Q51839118",
+    "seat_count": "9",
+    "area_id": "Q686586",
     "position_item_id": "Q51842232",
     "terms": [
       {
@@ -167,6 +197,8 @@
   {
     "comment": "departmental board of Canindeyú",
     "house_item_id": "Q51839120",
+    "seat_count": "10",
+    "area_id": "Q279085",
     "position_item_id": "Q51842235",
     "terms": [
       {
@@ -178,6 +210,8 @@
   {
     "comment": "departmental board of Presidente Hayes",
     "house_item_id": "Q51839121",
+    "seat_count": "8",
+    "area_id": "Q750551",
     "position_item_id": "Q51842237",
     "terms": [
       {
@@ -189,6 +223,8 @@
   {
     "comment": "departmental board of Boqueron",
     "house_item_id": "Q51839123",
+    "seat_count": "7",
+    "area_id": "Q741017",
     "position_item_id": "Q51842238",
     "terms": [
       {
@@ -200,6 +236,8 @@
   {
     "comment": "departmental board of Alto Paraguay",
     "house_item_id": "Q51839124",
+    "seat_count": "7",
+    "area_id": "Q682642",
     "position_item_id": "Q51842239",
     "terms": [
       {
@@ -211,6 +249,8 @@
   {
     "comment": "Municipal Board of Asuncion",
     "house_item_id": "Q51839125",
+    "seat_count": "24",
+    "area_id": "Q2933",
     "position_item_id": "Q51842240",
     "terms": [
       {
@@ -222,6 +262,8 @@
   {
     "comment": "Municipal Board of Ciudad del Este",
     "house_item_id": "Q51839131",
+    "seat_count": "9",
+    "area_id": "Q192235",
     "position_item_id": "Q51842246",
     "terms": [
       {


### PR DESCRIPTION
This PR does the minimum necessary to add position-data and area_id information.

A full legislative index refresh would have removed item-based terms for a number of departmental legislatures as the terms in Wikidata have finished and no current terms have been created.
